### PR TITLE
Allow spaces in executable path

### DIFF
--- a/ConsoleModuleLoader.cpp
+++ b/ConsoleModuleLoader.cpp
@@ -80,28 +80,6 @@ void ConsoleModuleLoader::LoadModule()
 	}
 }
 
-bool ConvertLPWToString(std::string& stringOut, const LPWSTR pw, UINT codepage = CP_ACP)
-{
-	bool result = false;
-	char* p = 0;
-
-	int bsz = WideCharToMultiByte(codepage, 0, pw, -1, 0, 0, 0, 0);
-
-	if (bsz > 0) {
-		p = new char[bsz];
-		int rc = WideCharToMultiByte(codepage, 0, pw, -1, p, bsz, 0, 0);
-		if (rc != 0) {
-			p[bsz - 1] = 0;
-			stringOut = p;
-			result = true;
-		}
-	}
-
-	delete[] p;
-
-	return result;
-}
-
 void ConsoleModuleLoader::ParseCommandLine(std::vector<std::string>& arguments)
 {
 	arguments.clear();
@@ -223,4 +201,28 @@ void ConsoleModuleLoader::RunModule()
 			runFunc();
 		}
 	}
+}
+
+bool ConsoleModuleLoader::ConvertLPWToString(std::string& stringOut, const LPWSTR pw, UINT codepage)
+{
+	// Code adapted from: https://gist.github.com/icreatetoeducate/4019717
+
+	bool result = false;
+	char* p = 0;
+
+	int bsz = WideCharToMultiByte(codepage, 0, pw, -1, 0, 0, 0, 0);
+
+	if (bsz > 0) {
+		p = new char[bsz];
+		int rc = WideCharToMultiByte(codepage, 0, pw, -1, p, bsz, 0, 0);
+		if (rc != 0) {
+			p[bsz - 1] = 0;
+			stringOut = p;
+			result = true;
+		}
+	}
+
+	delete[] p;
+
+	return result;
 }

--- a/ConsoleModuleLoader.cpp
+++ b/ConsoleModuleLoader.cpp
@@ -90,15 +90,22 @@ void ConsoleModuleLoader::ParseCommandLine(std::vector<std::string>& arguments)
 		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
 	}
 	else {
-		// Ignore the first argument, which is the path of the executable.
-		for (int i = 1; i < argumentCount; i++) {
-			std::string argument;
-			if (!ConvertLPWToString(argument, commandLineArgs[i])) {
-				PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to cast the " + std::to_string(i) + 
-					" command line argument from LPWSTR to char*. Further parsing of command line arguments aborted.");
-				break;
+		try {
+			// Ignore the first argument, which is the path of the executable.
+			for (int i = 1; i < argumentCount; i++) {
+				std::string argument;
+				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
+					PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to cast the " + std::to_string(i) +
+						" command line argument from LPWSTR to char*. Further parsing of command line arguments aborted.");
+					break;
+				}
+				arguments.push_back(argument);
 			}
-			arguments.push_back(argument);
+		}
+		// Catch and STL produced exceptions.
+		catch (std::exception& e) {
+			PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Error occurred attempting to parse command line arguments. Further parshing of command line arguments aborted. Internal Error: " + std::string(e.what()));
+			LocalFree(commandLineArgs);
 		}
 	}
 

--- a/ConsoleModuleLoader.h
+++ b/ConsoleModuleLoader.h
@@ -22,4 +22,6 @@ private:
 	std::string ParseLoadModCommand(std::vector<std::string> arguments);
 	std::string FormModRelativeDirectory(std::vector<std::string> arguments);
 	void SetArtPath();
+
+	static bool ConvertLPWToString(std::string& stringOut, const LPWSTR pw, UINT codepage = CP_ACP);
 };

--- a/ConsoleModuleLoader.h
+++ b/ConsoleModuleLoader.h
@@ -1,6 +1,5 @@
 #include "op2ext.h"
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 #include <string>


### PR DESCRIPTION
 - Properly parse the executable's path to not appear as multiple command arguments.
 - Improve error message when malformed command line arguments are encountered.