### PR TITLE
Standardize size t calls in c++ portions of code

### DIFF
--- a/ConsoleModuleLoader.cpp
+++ b/ConsoleModuleLoader.cpp
@@ -8,6 +8,7 @@
 #include <iterator>
 #include <filesystem>
 #include <stdexcept>
+#include <cstddef>
 
 namespace fs = std::experimental::filesystem;
 
@@ -157,7 +158,7 @@ std::string ConsoleModuleLoader::FormModRelativeDirectory(std::vector<std::strin
 {
 	std::string modRelativeDirectory;
 
-	for (size_t i = 0; i < arguments.size(); i++) {
+	for (std::size_t i = 0; i < arguments.size(); i++) {
 		modRelativeDirectory += arguments[i];
 
 		if (i < arguments.size() - 1) {

--- a/FileSystemHelper.cpp
+++ b/FileSystemHelper.cpp
@@ -2,6 +2,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <cstddef>
 #include <filesystem>
 
 namespace fs = std::experimental::filesystem;
@@ -26,8 +27,8 @@ std::string GetOutpost2IniPath()
 // Hides implementation detail of creating a buffer. Wraps call in std::string arguments and return. 
 std::string GetPrivateProfileStdString(std::string sectionName, std::string key, std::string filename)
 {
-	size_t bufferInterval = 1024;
-	size_t currentBufferSize = bufferInterval;
+	const std::size_t bufferInterval = 1024;
+	auto currentBufferSize = bufferInterval;
 	char* buffer = new char[currentBufferSize];
 
 	while (true)

--- a/GlobalDefines.cpp
+++ b/GlobalDefines.cpp
@@ -3,6 +3,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <sstream>
+#include <cstddef>
 
 void OutputDebug(std::string message)
 {
@@ -39,7 +40,7 @@ std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, c
 		return "";
 	}
 
-	size_t stringBegin = 0;
+	std::size_t stringBegin = 0;
 	if (trimOption == TrimOption::Leading || trimOption == TrimOption::Both) {
 		stringBegin = stringToTrim.find_first_not_of(whitespace);
 	}
@@ -48,7 +49,7 @@ std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, c
 		return ""; // no content provided
 	}
 
-	size_t stringEnd = stringToTrim.length();
+	auto stringEnd = stringToTrim.length();
 	if (trimOption == TrimOption::Trailing || trimOption == TrimOption::Both) {
 		stringEnd = stringToTrim.find_last_not_of(whitespace);
 	}

--- a/GlobalDefines.cpp
+++ b/GlobalDefines.cpp
@@ -44,12 +44,14 @@ std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, c
 		stringBegin = stringToTrim.find_first_not_of(whitespace);
 	}
 
-	if (stringBegin == std::string::npos)
+	if (stringBegin == std::string::npos) {
 		return ""; // no content provided
+	}
 
 	size_t stringEnd = stringToTrim.length();
-	if (trimOption == TrimOption::Trailing || trimOption == TrimOption::Both)
+	if (trimOption == TrimOption::Trailing || trimOption == TrimOption::Both) {
 		stringEnd = stringToTrim.find_last_not_of(whitespace);
+	}
 
 	const auto range = stringEnd - stringBegin + 1;
 

--- a/TestModule/TestFunctions.cpp
+++ b/TestModule/TestFunctions.cpp
@@ -3,13 +3,14 @@
 #include "op2ext.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <cstddef>
 #include <filesystem>
 
 namespace fs = std::experimental::filesystem;
 
 std::string GetOP2IniPath();
 std::string GetGameDirStdString();
-size_t CountVolFilesInGameDirectory();
+std::size_t CountVolFilesInGameDirectory();
 
 
 void TestGetGameDir_s()
@@ -55,10 +56,10 @@ void TestInvalidVolFileName()
 // vol files are loaded into Outpost 2.
 void TestTooManyVolFilesLoaded()
 {
-	size_t volsInGameDirectory = CountVolFilesInGameDirectory();
+	auto volsInGameDirectory = CountVolFilesInGameDirectory();
 
 	std::string volPath("./TestModule/TestVolume.vol");
-	for (size_t i = volsInGameDirectory; i < 32; i++)
+	for (auto i = volsInGameDirectory; i < 32; i++)
 	{
 		char* charPointer = new char[volPath.size() + 1];
 		strcpy_s(charPointer, volPath.size() + 1, volPath.c_str());
@@ -99,10 +100,10 @@ std::string GetGameDirStdString()
 	return std::string(gameDirectory);
 }
 
-size_t CountVolFilesInGameDirectory()
+std::size_t CountVolFilesInGameDirectory()
 {
 	std::string gameDirectory = GetGameDirStdString();
-	size_t volsInGameDirectory = 0;
+	std::size_t volsInGameDirectory = 0;
 
 	for (auto & p : fs::directory_iterator(fs::path(gameDirectory)))
 	{

--- a/op2ext.h
+++ b/op2ext.h
@@ -17,7 +17,7 @@ extern "C" {
 #define OP2EXT_API __declspec(dllimport) 
 #endif
 
-#include <stddef.h>
+#include <stddef.h> // size_t (C specific variant)
 
 
 // Retrieves the current absolute directory of the Outpost 2 executable with a trailing slash. 


### PR DESCRIPTION
This gets a little weird, but the C compatible portions of the code use size_t from stddef.h and the C++ only portions of the code use std::size_t from cstddef now. 

Also some minor improvements like adding brackets around single line if statements and using auto in a few places.