### PR TITLE
Use malloc instead of new to allocate in external C API function GetCurrentModDir

### DIFF
--- a/op2ext.cpp
+++ b/op2ext.cpp
@@ -47,7 +47,7 @@ OP2EXT_API char* GetCurrentModDir()
 		return nullptr;
 	}
 
-	char* cStr = new char[modDirectory.length() + 1];
+	char* cStr = static_cast<char*>(malloc(modDirectory.length() + 1));
 	strcpy_s(cStr, modDirectory.length() + 1, modDirectory.c_str());
 
 	return cStr;


### PR DESCRIPTION
This fixes a legitimate bug in op2ext's external API. Perhaps we should role it into Outpost 2 before the next release of the game?

Also, not sure if we want to use static_cast there or c style cast. I think it is okay to call the static_cast here since the cast doesn't affect what is passed outside of the function and across DLL boundaries. 

Closes #8