### PR TITLE
Add Appveyor automated build process

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,11 @@
+image: Visual Studio 2017
+configuration:
+  - Debug
+  - Release
+platform:
+  - x86
+install:
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - git submodule update --init --recursive
+build:
+  project: op2ext.sln

--- a/op2ext.vcxproj
+++ b/op2ext.vcxproj
@@ -45,11 +45,13 @@
     <OutDir>.\Release\</OutDir>
     <IntDir>.\Release\</IntDir>
     <LinkIncremental>false</LinkIncremental>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <OutDir>.\Debug\</OutDir>
     <IntDir>.\Debug\</IntDir>
     <LinkIncremental>false</LinkIncremental>
+    <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -68,7 +70,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" ".\Outpost2"</Command>
+      <Command>xcopy /y /d "$(TargetPath)" ".\Outpost2\"</Command>
     </PostBuildEvent>
     <Midl>
       <SuppressStartupBanner>true</SuppressStartupBanner>
@@ -145,7 +147,7 @@
       <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <PostBuildEvent>
-      <Command>copy "$(TargetPath)" ".\Outpost2"</Command>
+      <Command>xcopy /y /d "$(TargetPath)" ".\Outpost2\"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
 - Update post build script to work in automated build process.

The post build script had to be updated. xcopy requires input on whether the source is a directory or a filename when the directory does not exist, hence the `echo D|` line. I hadn't noticed until now since the Outpost2 directory already existed in my development process. This post build event doesn't add anything to the appveyor build process, but I didn't see an easy way to turn it off only in the appveyor build so figured it was fine to let it run anyways.

-Brett