### PR TITLE
Mark input strings as const in exported methods

### DIFF
--- a/op2ext.cpp
+++ b/op2ext.cpp
@@ -65,7 +65,7 @@ OP2EXT_API char* GetCurrentModDir()
 	return cStr;
 }
 
-OP2EXT_API void AddVolToList(char* volFilename)
+OP2EXT_API void AddVolToList(const char* volFilename)
 {
 	if (modulesRunning) {
 		PostErrorMessage("op2ext.cpp", __LINE__, "VOLs may not be added to the list after game startup.");
@@ -88,7 +88,7 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 	}
 }
 
-OP2EXT_API void Log(char* message)
+OP2EXT_API void Log(const char* message)
 {
 	// The return address will (normally) point into the code section
 	// of the caller. The address can then be used to lookup which

--- a/op2ext.h
+++ b/op2ext.h
@@ -48,7 +48,7 @@ OP2EXT_API char* GetCurrentModDir();
 // initializes. Typically should be called in module's mod_init (InitMod) function.
 // @param volFilename The vol filename ending in a null terminated string. 
 //                    Must be a relative path from the directory containing the Outpost 2 executable.
-OP2EXT_API void AddVolToList(char* volFilename);
+OP2EXT_API void AddVolToList(const char* volFilename);
 
 
 // Overwrites the default Outpost 2 version string.
@@ -57,7 +57,7 @@ OP2EXT_API void AddVolToList(char* volFilename);
 OP2EXT_API void SetSerialNumber(char major, char minor, char patch);
 
 // Log a message in Outpost2Log.txt.
-OP2EXT_API void Log(char* message);
+OP2EXT_API void Log(const char* message);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
Noticed a small oversight when I tried to compile the test modules with Mingw. It gives a warning about how ISO C++ forbids automatic conversions from `const char*` to `char*` when the call sites try to pass a string literal (which is a `const char*`).
