### PR TITLE
Add public max volume count property

### DIFF
--- a/TestModule/DllMain.cpp
+++ b/TestModule/DllMain.cpp
@@ -79,8 +79,7 @@ void TestPublicInterface()
 	TestGetGameDir_s();
 	TestGetGameDir();
 
-	TestInvalidVolFileName();
-	TestTooManyVolFilesLoaded();
+	TestLoadingVolumes();
 
 	// Test SetSerialNumber by attempting to start a multiplayer match. 
 	// One copy of Outpost 2 stock, and one with the serial number modified. 

--- a/TestModule/TestFunctions.cpp
+++ b/TestModule/TestFunctions.cpp
@@ -1,6 +1,6 @@
 #include "TestFunctions.h"
 #include "CountFilesByTypeInDirectory.h"
-
+#include "VolList.h"
 #include "op2ext.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -56,20 +56,18 @@ void TestGetConsoleModDir()
 	free(moduleDirectory);
 }
 
-void TestInvalidVolFileName()
+void TestLoadingVolumes()
 {
+	// Test Invalid volume filename (volume doesn't exist in directory)
 	AddVolToList("VolumeLoadFail.vol");
-}
 
-// This function will cause Outpost 2 to not load properly if an essential vol file is not properly loaded.
-// Recommend adding a vol file that is alphabetically after voices.vol. This way voices.vol and all essential 
-// vol files are loaded into Outpost 2.
-void TestTooManyVolFilesLoaded()
-{
-	auto volsInGameDirectory = CountFilesByTypeInDirectory(GetGameDirStdString(), ".vol");
+	// Reserve enough space to load existing volumes in Outpost 2 directory.
+	// Outpost 2 will not load properly if certain files contained in volumes are not present.
+	auto loadedVolumes = CountFilesByTypeInDirectory(GetGameDirStdString(), ".vol");
+	loadedVolumes++; // Reserve space for VolumeLoadFail.vol
 
 	std::string volPath("./TestModule/TestVolume.vol");
-	for (auto i = volsInGameDirectory; i < 31; i++)
+	for (auto i = loadedVolumes; i < VolList::MaxVolumeCount + 1; ++i)
 	{
 		AddVolToList(volPath.c_str());
 	}

--- a/TestModule/TestFunctions.cpp
+++ b/TestModule/TestFunctions.cpp
@@ -66,8 +66,10 @@ void TestLoadingVolumes()
 	auto loadedVolumes = CountFilesByTypeInDirectory(GetGameDirStdString(), ".vol");
 	loadedVolumes++; // Reserve space for VolumeLoadFail.vol
 
-	std::string volPath("./TestModule/TestVolume.vol");
-	for (auto i = loadedVolumes; i < VolList::MaxVolumeCount + 1; ++i)
+	const std::string volPath("./TestModule/TestVolume.vol");
+	const auto exceededVolCountLimit = VolList::MaxVolumeCount + 1;
+
+	for (auto i = loadedVolumes; i < exceededVolCountLimit; ++i)
 	{
 		AddVolToList(volPath.c_str());
 	}

--- a/TestModule/TestFunctions.h
+++ b/TestModule/TestFunctions.h
@@ -6,7 +6,6 @@ void TestLoggingMessage();
 void TestGetGameDir_s();
 void TestGetGameDir(); //Deprecated
 void TestGetConsoleModDir_s();
-void TestGetConsoleModDir();
-void TestInvalidVolFileName();
-void TestTooManyVolFilesLoaded();
+void TestGetConsoleModDir(); //Deprecated
+void TestLoadingVolumes(); //Test loading a non-existent volume & loading too many volumes
 void TestIniSectionName(std::string sectionName);

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -58,7 +58,7 @@ void VolList::LoadVolFiles()
 	Op2MemSetDword((void*)0x0047111F, vol4);
 }
 
-bool VolList::IsFull()
+bool VolList::IsFull() const
 {
 	return numberOfVolFiles >= VolSearchBufferSize - 1;
 }

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -60,7 +60,7 @@ void VolList::LoadVolFiles()
 
 bool VolList::IsFull() const
 {
-	return volFileCount >= VolSearchBufferSize - 1;
+	return volFileCount >= MaxVolumeCount;
 }
 
 void VolList::InitializeVolSearchEntry(char* pVolPath)

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -30,8 +30,8 @@ void VolList::LoadVolFiles()
 
 	VolSearchEntry *vol = &volSearchEntryList[0];
 	int *vol2 = &volSearchEntryList[0].unknown1;
-	int *vol3 = &volSearchEntryList[numberOfVolFiles].unknown1;
-	VolSearchEntry *vol4 = &volSearchEntryList[numberOfVolFiles - 1];
+	int *vol3 = &volSearchEntryList[volFileCount].unknown1;
+	VolSearchEntry *vol4 = &volSearchEntryList[volFileCount - 1];
 
 	// Change operand of the MOV instruction
 	Op2MemSetDword((void*)0x00471070, vol);
@@ -60,17 +60,17 @@ void VolList::LoadVolFiles()
 
 bool VolList::IsFull() const
 {
-	return numberOfVolFiles >= VolSearchBufferSize - 1;
+	return volFileCount >= VolSearchBufferSize - 1;
 }
 
 void VolList::InitializeVolSearchEntry(char* pVolPath)
 {
-	volSearchEntryList[numberOfVolFiles].unknown1 = 0;
-	volSearchEntryList[numberOfVolFiles].flags = 1;
-	volSearchEntryList[numberOfVolFiles].unknown2 = 0;
-	volSearchEntryList[numberOfVolFiles].pFilename = pVolPath;
+	volSearchEntryList[volFileCount].unknown1 = 0;
+	volSearchEntryList[volFileCount].flags = 1;
+	volSearchEntryList[volFileCount].unknown2 = 0;
+	volSearchEntryList[volFileCount].pFilename = pVolPath;
 
-	numberOfVolFiles++;
+	volFileCount++;
 }
 
 void VolList::EndList()

--- a/VolList.h
+++ b/VolList.h
@@ -22,14 +22,16 @@ public:
 	// Load all identified vol files into Outpost 2's memory.
 	void LoadVolFiles();
 
+	static const unsigned MaxVolumeCount = 31;
+
 private:
 	std::vector<std::vector<char>> volPaths;
 	unsigned int volFileCount;
 	VolSearchEntry* volSearchEntryList;
 	
 	// Static buffer, to avoid dynamic memory allocation before heap is initialized
-	static const unsigned int VolSearchBufferSize = 32;
-	VolSearchEntry buffer[VolSearchBufferSize];
+	// buffer size must include an extra entry for an end of list marker 
+	VolSearchEntry buffer[MaxVolumeCount + 1];
 
 	bool IsFull() const;
 	void InitializeVolSearchEntry(char* pVolPath);

--- a/VolList.h
+++ b/VolList.h
@@ -31,7 +31,7 @@ private:
 	static const unsigned int VolSearchBufferSize = 32;
 	VolSearchEntry buffer[VolSearchBufferSize];
 
-	bool IsFull();
+	bool IsFull() const;
 	void InitializeVolSearchEntry(char* pVolPath);
 	void EndList();
 };

--- a/VolList.h
+++ b/VolList.h
@@ -24,7 +24,7 @@ public:
 
 private:
 	std::vector<std::vector<char>> volPaths;
-	unsigned int numberOfVolFiles;
+	unsigned int volFileCount;
 	VolSearchEntry* volSearchEntryList;
 	
 	// Static buffer, to avoid dynamic memory allocation before heap is initialized

--- a/VolList.h
+++ b/VolList.h
@@ -29,8 +29,8 @@ private:
 	unsigned int volFileCount;
 	VolSearchEntry* volSearchEntryList;
 	
-	// Static buffer, to avoid dynamic memory allocation before heap is initialized
-	// buffer size must include an extra entry for an end of list marker 
+	// Static size, to avoid dynamic memory allocation before heap is initialized
+	// Buffer must include an extra terminator entry for an end of list marker 
 	VolSearchEntry buffer[MaxVolumeCount + 1];
 
 	bool IsFull() const;


### PR DESCRIPTION
Just realized that calling the test function `TestInvalidVolFileName()` adds a volume to VolList that does not exist in the directory. This is what is throwing the count off in `TestTooManyVolFilesLoaded()`. `TestTooManyVolFilesLoaded()` counts the volumes listed in the directory but doesn't understand that one is added that doesn't exist to test failure. We need to account for this volume addition to get the numbers right.

**Don't think the idea below would work or is really necessary.**
~~@DanRStevens, what do you think of adding a property~~ 

```C++
inline unsigned VolList::GetVolFileCount() const { return volFileCount; }
```

~~We would have to give the test code direct access to the VolList instance used by op2ext by including the header op2ext-internal.h in the test code.~~

~~This would allow accounting for any pretend volumes loaded into VolFile before checking the max buffer size. This is getting a bit complicated.~~

I'm done for a while, so please hack away at this branch. 

Thanks,
Brett 