### PR TITLE
Remove x64 compilation settings from TestModule project

### DIFF
--- a/TestModule/TestModule.vcxproj
+++ b/TestModule/TestModule.vcxproj
@@ -9,14 +9,6 @@
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
-    <ProjectConfiguration Include="Debug|x64">
-      <Configuration>Debug</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
-    <ProjectConfiguration Include="Release|x64">
-      <Configuration>Release</Configuration>
-      <Platform>x64</Platform>
-    </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>15.0</VCProjectVersion>
@@ -38,19 +30,6 @@
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>MultiByte</CharacterSet>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
@@ -60,12 +39,6 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
@@ -93,13 +66,6 @@ copy "$(TargetPath)" "..\Outpost2\TestModule\$(TargetFileName)"
 copy "$(ProjectDir)TestVolume.vol" "..\Outpost2\TestModule\TestVolume.vol"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <SDLCheck>true</SDLCheck>
-    </ClCompile>
-  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
@@ -121,19 +87,6 @@ copy "$(ProjectDir)TestVolume.vol" "..\Outpost2\TestModule\TestVolume.vol"</Comm
 copy "$(TargetPath)" "..\Outpost2\TestModule\$(TargetFileName)"
 copy "$(ProjectDir)TestVolume.vol" "..\Outpost2\TestModule\TestVolume.vol"</Command>
     </PostBuildEvent>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <SDLCheck>true</SDLCheck>
-    </ClCompile>
-    <Link>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-    </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="CompatibilityTest.c" />

--- a/op2ext.sln
+++ b/op2ext.sln
@@ -17,30 +17,20 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Outpost2DLL", "Submodules\O
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Debug|x64.ActiveCfg = Debug|Win32
 		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Debug|x86.ActiveCfg = Debug|Win32
 		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Debug|x86.Build.0 = Debug|Win32
-		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Release|x64.ActiveCfg = Release|Win32
 		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Release|x86.ActiveCfg = Release|Win32
 		{6DE3610C-C9EE-4FD3-BBD7-66382C16FDE9}.Release|x86.Build.0 = Release|Win32
-		{19622CEB-6837-4B41-81E2-21969D813C6A}.Debug|x64.ActiveCfg = Debug|x64
-		{19622CEB-6837-4B41-81E2-21969D813C6A}.Debug|x64.Build.0 = Debug|x64
 		{19622CEB-6837-4B41-81E2-21969D813C6A}.Debug|x86.ActiveCfg = Debug|Win32
 		{19622CEB-6837-4B41-81E2-21969D813C6A}.Debug|x86.Build.0 = Debug|Win32
-		{19622CEB-6837-4B41-81E2-21969D813C6A}.Release|x64.ActiveCfg = Release|x64
-		{19622CEB-6837-4B41-81E2-21969D813C6A}.Release|x64.Build.0 = Release|x64
 		{19622CEB-6837-4B41-81E2-21969D813C6A}.Release|x86.ActiveCfg = Release|Win32
 		{19622CEB-6837-4B41-81E2-21969D813C6A}.Release|x86.Build.0 = Release|Win32
-		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Debug|x64.ActiveCfg = Debug|Win32
 		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Debug|x86.ActiveCfg = Debug|Win32
 		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Debug|x86.Build.0 = Debug|Win32
-		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Release|x64.ActiveCfg = Release|Win32
 		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Release|x86.ActiveCfg = Release|Win32
 		{B3F40368-F3CC-4EC5-A758-F5DAD08FEDDC}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection


### PR DESCRIPTION
There should never be a reason to compile in x64 since op2ext is only compiled in x86 (WIN32)