### PR TITLE
Include experimental filesystem

### DIFF
--- a/ConsoleModuleLoader.cpp
+++ b/ConsoleModuleLoader.cpp
@@ -6,7 +6,7 @@
 #include <sstream>
 #include <algorithm>
 #include <iterator>
-#include <filesystem>
+#include <experimental/filesystem>
 #include <stdexcept>
 #include <cstddef>
 

--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -7,7 +7,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
-#include <filesystem>
+#include <experimental/filesystem>
 #include <algorithm>
 
 namespace fs = std::experimental::filesystem;

--- a/FileSystemHelper.cpp
+++ b/FileSystemHelper.cpp
@@ -3,7 +3,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <cstddef>
-#include <filesystem>
+#include <experimental/filesystem>
 
 namespace fs = std::experimental::filesystem;
 


### PR DESCRIPTION
As we are using `namespace fs = std::experimental::filesystem;`, it's probably more correct to include the experimental header.

As a bonus, I've found that MinGW is able to handle code with `#include <experimental/filesystem>`, but not code that uses `#include <filesystem>`. This opens up more opportunity for compiler checks of the code base, or cross compilation.
