### PR TITLE
Add missing `<cstring>` header

### DIFF
--- a/FileSystemHelper.cpp
+++ b/FileSystemHelper.cpp
@@ -2,6 +2,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <cstring>
 #include <cstddef>
 #include <filesystem>
 


### PR DESCRIPTION
This headed is needed for `std::strlen`.