### PR TITLE
Rename `p` to `dirEntry` for clarity

### DIFF
--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -120,9 +120,9 @@ void LocateVolFiles(std::string relativeSearchDirectory)
 {
 	std::string gameDirectory = GetGameDirectory();
 
-	for (auto & p : fs::directory_iterator(fs::path(gameDirectory).append(relativeSearchDirectory)))
+	for (auto& dirEntry : fs::directory_iterator(fs::path(gameDirectory).append(relativeSearchDirectory)))
 	{
-		fs::path filePath(p.path());
+		fs::path filePath(dirEntry.path());
 
 		std::string extension = filePath.extension().string();
 		std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);

--- a/DllMain.cpp
+++ b/DllMain.cpp
@@ -120,9 +120,9 @@ void LocateVolFiles(std::string relativeSearchDirectory)
 {
 	std::string gameDirectory = GetGameDirectory();
 
-	for (auto& dirEntry : fs::directory_iterator(fs::path(gameDirectory).append(relativeSearchDirectory)))
+	for (const auto& dirEntry : fs::directory_iterator(fs::path(gameDirectory).append(relativeSearchDirectory)))
 	{
-		fs::path filePath(dirEntry.path());
+		const auto& filePath = dirEntry.path();
 
 		std::string extension = filePath.extension().string();
 		std::transform(extension.begin(), extension.end(), extension.begin(), ::tolower);


### PR DESCRIPTION
Using the name `p` was suggestive that it was a `path` type, rather than a `directory_entry` type. This made construction of `filePath` from `p` appear to be redundant.