### PR TITLE
Vol list update defer creation

### DIFF
--- a/TestModule/TestFunctions.cpp
+++ b/TestModule/TestFunctions.cpp
@@ -1,6 +1,5 @@
 #include "TestFunctions.h"
 #include "CountFilesByTypeInDirectory.h"
-#include "VolList.h"
 #include "op2ext.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -67,9 +66,9 @@ void TestLoadingVolumes()
 	loadedVolumes++; // Reserve space for VolumeLoadFail.vol
 
 	const std::string volPath("./TestModule/TestVolume.vol");
-	const auto exceededVolCountLimit = VolList::MaxVolumeCount + 1;
-
-	for (auto i = loadedVolumes; i < exceededVolCountLimit; ++i)
+	
+	// Test loading 100 volumes
+	for (auto i = loadedVolumes; i < 100; ++i)
 	{
 		AddVolToList(volPath.c_str());
 	}

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -3,21 +3,10 @@
 #include "GlobalDefines.h"
 #include <utility>
 
-
-VolList::VolList()
-{
-	volSearchEntryList = buffer;
-}
-
 VolList::~VolList() { }
 
 void VolList::AddVolFile(std::string volPath)
 {
-	if (IsFull()) {
-		PostErrorMessage("VolList.cpp", __LINE__, "Too many vol files loaded. Ignoring the vol file '" + volPath + "'");
-		return;
-	}
-	
 	volPaths.push_back(std::move(volPath));
 
 	OutputDebug("Add file to VolList: " + volPath + "\n");
@@ -57,15 +46,13 @@ void VolList::LoadVolFiles()
 	Op2MemSetDword((void*)0x0047111F, vol4);
 }
 
-bool VolList::IsFull() const
-{
-	return volPaths.size() >= MaxVolumeCount;
-}
-
 // After calling CreateVolSearchEntryList, do not change the contents of volPaths. 
 // If Small String Optimization (SSO) is applied by the compiler, the associated pointers will become invalid.
 std::size_t VolList::CreateVolSearchEntryList()
 {
+	// Buffer must include an extra terminator entry for an end of list marker
+	volSearchEntryList = std::make_unique<VolSearchEntry[]>(volPaths.size() + 1);
+
 	std::size_t volEntryListSize = 0;
 	for (volEntryListSize; volEntryListSize < volPaths.size(); ++volEntryListSize) {
 		volSearchEntryList[volEntryListSize] = VolSearchEntry{ volPaths[volEntryListSize].c_str(), 0, 1, 0 };

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -2,7 +2,7 @@
 #include "OP2Memory.h"
 #include "GlobalDefines.h"
 #include <utility>
-#include <cstddef>
+
 
 VolList::VolList()
 {
@@ -25,12 +25,12 @@ void VolList::AddVolFile(std::string volPath)
 
 void VolList::LoadVolFiles()
 {
-	CreateVolSearchEntryList();
+	std::size_t volEntryListSize = CreateVolSearchEntryList();
 
 	VolSearchEntry *vol = &volSearchEntryList[0];
 	int *vol2 = &volSearchEntryList[0].unknown1;
-	int *vol3 = &volSearchEntryList[volPaths.size() - 1].unknown1;
-	VolSearchEntry *vol4 = &volSearchEntryList[volPaths.size() - 2];
+	int *vol3 = &volSearchEntryList[volEntryListSize].unknown1;
+	VolSearchEntry *vol4 = &volSearchEntryList[volEntryListSize - 1];
 
 	// Change operand of the MOV instruction
 	Op2MemSetDword((void*)0x00471070, vol);
@@ -64,12 +64,16 @@ bool VolList::IsFull() const
 
 // After calling CreateVolSearchEntryList, do not change the contents of volPaths. 
 // If Small String Optimization (SSO) is applied by the compiler, the associated pointers will become invalid.
-void VolList::CreateVolSearchEntryList()
+std::size_t VolList::CreateVolSearchEntryList()
 {
-	for (std::size_t i = 0; i < volPaths.size(); ++i) {
-		volSearchEntryList[i] = VolSearchEntry{ volPaths[i].c_str(), 0, 1, 0 };
+	std::size_t volEntryListSize = 0;
+	for (volEntryListSize; volEntryListSize < volPaths.size(); ++volEntryListSize) {
+		volSearchEntryList[volEntryListSize] = VolSearchEntry{ volPaths[volEntryListSize].c_str(), 0, 1, 0 };
 	}
 
 	// Add end of volFileEntries search item.
-	volSearchEntryList[volPaths.size()] = VolSearchEntry{ nullptr, 0, 1, 0 };
+	volSearchEntryList[volEntryListSize] = VolSearchEntry{ nullptr, 0, 1, 0 };
+	volEntryListSize++;
+
+	return volEntryListSize;
 }

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -7,6 +7,9 @@
 VolList::VolList()
 {
 	volSearchEntryList = buffer;
+	// Bug workaround: Pre-allocate space for all strings so there is no resizing
+	// Resizing can move strings around, which invalidates the c_str() pointer
+	volPaths.reserve(MaxVolumeCount);
 }
 
 VolList::~VolList() { }

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -17,9 +17,8 @@ void VolList::AddVolFile(std::string volPath)
 		return;
 	}
 	
-	volPaths.push_back(std::vector<char>(volPath.c_str(), volPath.c_str() + volPath.size() + 1u));
-	
-	InitializeVolSearchEntry(&volPaths.back()[0]);
+	volPaths.push_back(volPath);
+	InitializeVolSearchEntry(volPaths.back().c_str());
 
 	OutputDebug("Add file to VolList: " + volPath + "\n");
 }

--- a/VolList.cpp
+++ b/VolList.cpp
@@ -1,7 +1,8 @@
 #include "VolList.h"
-
 #include "OP2Memory.h"
 #include "GlobalDefines.h"
+#include <utility>
+
 
 VolList::VolList()
 {
@@ -17,7 +18,7 @@ void VolList::AddVolFile(std::string volPath)
 		return;
 	}
 	
-	volPaths.push_back(volPath);
+	volPaths.push_back(std::move(volPath));
 	InitializeVolSearchEntry(volPaths.back().c_str());
 
 	OutputDebug("Add file to VolList: " + volPath + "\n");

--- a/VolList.h
+++ b/VolList.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <vector>
+#include <cstddef>
 
 struct VolSearchEntry {
 	const char* pFilename;
@@ -27,11 +28,13 @@ public:
 private:
 	std::vector<std::string> volPaths;
 	VolSearchEntry* volSearchEntryList;
-	
+
 	// Static size, to avoid dynamic memory allocation before heap is initialized
 	// Buffer must include an extra terminator entry for an end of list marker 
 	VolSearchEntry buffer[MaxVolumeCount + 1];
 
 	bool IsFull() const;
-	void CreateVolSearchEntryList();
+
+	// Return size of VolSearchEntryList
+	std::size_t CreateVolSearchEntryList();
 };

--- a/VolList.h
+++ b/VolList.h
@@ -26,7 +26,6 @@ public:
 
 private:
 	std::vector<std::string> volPaths;
-	unsigned int volFileCount;
 	VolSearchEntry* volSearchEntryList;
 	
 	// Static size, to avoid dynamic memory allocation before heap is initialized
@@ -34,6 +33,5 @@ private:
 	VolSearchEntry buffer[MaxVolumeCount + 1];
 
 	bool IsFull() const;
-	void InitializeVolSearchEntry(const char* pVolPath);
-	void EndList();
+	void CreateVolSearchEntryList();
 };

--- a/VolList.h
+++ b/VolList.h
@@ -25,7 +25,7 @@ public:
 	static const unsigned MaxVolumeCount = 31;
 
 private:
-	std::vector<std::vector<char>> volPaths;
+	std::vector<std::string> volPaths;
 	unsigned int volFileCount;
 	VolSearchEntry* volSearchEntryList;
 	

--- a/VolList.h
+++ b/VolList.h
@@ -3,6 +3,7 @@
 #include <string>
 #include <vector>
 #include <cstddef>
+#include <memory>
 
 struct VolSearchEntry {
 	const char* pFilename;
@@ -15,7 +16,6 @@ struct VolSearchEntry {
 class VolList  
 {
 public:
-	VolList();
 	virtual ~VolList();
 
 	void AddVolFile(std::string volPath);
@@ -23,17 +23,9 @@ public:
 	// Load all identified vol files into Outpost 2's memory.
 	void LoadVolFiles();
 
-	static const unsigned MaxVolumeCount = 31;
-
 private:
 	std::vector<std::string> volPaths;
-	VolSearchEntry* volSearchEntryList;
-
-	// Static size, to avoid dynamic memory allocation before heap is initialized
-	// Buffer must include an extra terminator entry for an end of list marker 
-	VolSearchEntry buffer[MaxVolumeCount + 1];
-
-	bool IsFull() const;
+	std::unique_ptr<VolSearchEntry[]> volSearchEntryList;
 
 	// Return size of VolSearchEntryList
 	std::size_t CreateVolSearchEntryList();


### PR DESCRIPTION
Thanks to the tips left by @DanRStevens in branch #26, I was able to get this working. I went ahead and updated to allow adding near infinite volumes to Outpost 2. (Well probably SIZE_MAX volumes). It came together easier than I thought.

**TODO list:**
 - Does VolList still need a destructor? I think there was some weird C++ rule about destructors needing be virtually present for inheritance to work but not sure if any of that applies sense there is no inheritance happening:
 - Update comments in LoadVolFiles(), in particular: 

```C++
// VolumeList+4 a bunch of other subs want. Better change those
//memcpy((void*)0x00471142, &vol2, 4);
...
// The 2nd element of the null entry some stuff wants
```
 - Consider removing code in TestModule associated with `CountFilesByTypeInDirectory`. We no longer need to know how many volumes are loaded to test if we are loading too many. It might be useful to leave in so we know exactly how many volumes are loaded when stress testing. IE we loaded exactly 100 volumes and it failed instead of loading 100 + some other number. 

Happy to tackle these in this branch or merge and move the list to the other branch.

Thanks
-Brett