### PR TITLE
Use two stage extern declaration and init

### DIFF
--- a/op2ext.cpp
+++ b/op2ext.cpp
@@ -15,7 +15,8 @@ size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer
 // Dummy export for linking requirements from Outpost2.exe and OP2Shell.dll. 
 // Outpost2.exe and OP2Shell.dll reference this dummy entry, causing op2ext.dll to load. 
 // It is not used in any way, but must exist to prevent Windows loader errors.
-extern "C" OP2EXT_API int StubExt = 0;
+extern "C" OP2EXT_API int StubExt;
+int StubExt = 0;
 
 OP2EXT_API size_t GetGameDir_s(char* buffer, size_t bufferSize)
 {


### PR DESCRIPTION
Doing both at the same time results in a warning from MinGW.

This partially addresses issue #31.
