### PR TITLE
Provide a message box and log error if console module fails to load its dll

### DIFF
--- a/ConsoleModuleLoader.cpp
+++ b/ConsoleModuleLoader.cpp
@@ -69,15 +69,28 @@ void ConsoleModuleLoader::LoadModule()
 
 	SetArtPath();
 
-	std::string dllName = fs::path(moduleDirectory).append("\\op2mod.dll").string();
+	LoadModuleDll();
+}
+
+void ConsoleModuleLoader::LoadModuleDll()
+{
+	const std::string dllName = fs::path(moduleDirectory).append("\\op2mod.dll").string();
+
+	if (!fs::exists(dllName)) {
+		return; // Some console modules do not contain dlls
+	}
+
 	modDllHandle = LoadLibrary(dllName.c_str());
 
 	if (modDllHandle) {
-		// Call its mod_init func
+		// Call module's mod_init function
 		FARPROC startFunc = GetProcAddress(modDllHandle, "mod_init");
 		if (startFunc) {
 			startFunc();
 		}
+	}
+	else {
+		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to load console module's dll from " + dllName);
 	}
 }
 

--- a/ConsoleModuleLoader.h
+++ b/ConsoleModuleLoader.h
@@ -15,6 +15,7 @@ private:
 	HINSTANCE modDllHandle = nullptr;
 
 	std::string FindModuleDirectory();
+	void LoadModuleDll();
 	void ParseCommandLine(std::vector<std::string>& arguments);
 	bool ParseArgumentName(std::string& argument);
 	std::string ParseLoadModCommand(std::vector<std::string> arguments);


### PR DESCRIPTION
Some console modules will not contain a dll, so does not report an error if the dll does not exist where expected

If we want to pursue the next step, it might be logging an exception if attempting to load the module throws or pulling the error message when LoadLibrary returns a null pointer via GetLastError.

https://msdn.microsoft.com/en-us/d852e148-985c-416f-a5a7-27b6914b45d4

Closes #37 