### PR TITLE
Pass string as const parameter

### DIFF
--- a/WindowsErrorCode.cpp
+++ b/WindowsErrorCode.cpp
@@ -2,7 +2,7 @@
 #include "StringConversion.h"
 #include <strsafe.h> //Header requires WindowsXP SP2 or greater
 
-std::string GetLastErrorStdString(LPTSTR lpszFunction)
+std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 {
 	// Adapted from https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-the-last-error-code
 
@@ -20,7 +20,7 @@ std::string GetLastErrorStdString(LPTSTR lpszFunction)
 		0, NULL);
 
 	LPVOID lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT,
-		(lstrlen((LPCTSTR)lpMsgBuf) + lstrlen((LPCTSTR)lpszFunction) + 40) * sizeof(TCHAR));
+		(lstrlen((LPCTSTR)lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR));
 	
 	StringCchPrintf((LPTSTR)lpDisplayBuf,
 		LocalSize(lpDisplayBuf) / sizeof(TCHAR),

--- a/WindowsErrorCode.cpp
+++ b/WindowsErrorCode.cpp
@@ -19,15 +19,15 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 		reinterpret_cast<LPTSTR>(&lpMsgBuf),
 		0, NULL);
 
-	LPVOID lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT,
-		(lstrlen(lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR));
+	LPTSTR lpDisplayBuf = static_cast<LPTSTR>(LocalAlloc(LMEM_ZEROINIT,
+		(lstrlen(lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR)));
 	
-	StringCchPrintf((LPTSTR)lpDisplayBuf,
+	StringCchPrintf(lpDisplayBuf,
 		LocalSize(lpDisplayBuf) / sizeof(TCHAR),
 		TEXT("%s failed with error %d: %s"),
 		lpszFunction, dw, lpMsgBuf);
 
-	std::string errorMessage = ConvertLpctstrToString(static_cast<LPCTSTR>(lpDisplayBuf));
+	std::string errorMessage = ConvertLpctstrToString(lpDisplayBuf);
 
 	LocalFree(lpMsgBuf);
 	LocalFree(lpDisplayBuf);

--- a/WindowsErrorCode.cpp
+++ b/WindowsErrorCode.cpp
@@ -6,7 +6,7 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 {
 	// Adapted from https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-the-last-error-code
 
-	LPVOID lpMsgBuf;
+	LPTSTR lpMsgBuf;
 	DWORD dw = GetLastError();
 
 	FormatMessage(
@@ -16,11 +16,11 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 		NULL,
 		dw,
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-		(LPTSTR)&lpMsgBuf,
+		reinterpret_cast<LPTSTR>(&lpMsgBuf),
 		0, NULL);
 
 	LPVOID lpDisplayBuf = (LPVOID)LocalAlloc(LMEM_ZEROINIT,
-		(lstrlen((LPCTSTR)lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR));
+		(lstrlen(lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR));
 	
 	StringCchPrintf((LPTSTR)lpDisplayBuf,
 		LocalSize(lpDisplayBuf) / sizeof(TCHAR),

--- a/WindowsErrorCode.h
+++ b/WindowsErrorCode.h
@@ -3,4 +3,4 @@
 #include <string>
 
 // Retrieve the system error message for the last-error code
-std::string GetLastErrorStdString(LPTSTR lpszFunction);
+std::string GetLastErrorStdString(LPCTSTR lpszFunction);


### PR DESCRIPTION
The first commit fixes a compile warning from Mingw, where a string literal was being passed as a non-const char pointer.

The later two commits use more explicit variable types to reduce casting needs. The remaining needed casts were converted from the C-style casts to C++-style casts.
