### PR TITLE
Update makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -76,6 +76,10 @@ gtest:
 	cp -r $(GTESTINCDIR) $(GTESTLOCALINCDIR)
 
 
+# Objects with references to Outpost2DLL or _ReturnAddress are a problem for the linker
+OBJSWITHREFS := $(OBJDIR)/DllMain.o $(OBJDIR)/IpDropDown.o $(OBJDIR)/op2ext.o
+SRCOBJS := $(filter-out $(OBJSWITHREFS),$(OBJS)) # Remove objects with problem references
+
 TESTDIR := test
 TESTOBJDIR := $(BUILDDIR)/testObj
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
@@ -94,7 +98,7 @@ TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 check: $(TESTOUTPUT)
 	cd test && ../$(TESTOUTPUT)
 
-$(TESTOUTPUT): $(TESTOBJS) $(OBJS)
+$(TESTOUTPUT): $(TESTOBJS) $(SRCOBJS)
 	@mkdir -p ${@D}
 	$(CXX) $^ $(TESTLDFLAGS) $(TESTLIBS) -o $@
 

--- a/makefile
+++ b/makefile
@@ -8,6 +8,7 @@
 
 # Set compiler to mingw (can still override from command line)
 CXX := i686-w64-mingw32-g++
+CC := i686-w64-mingw32-gcc
 
 SRCDIR := .
 BUILDDIR := .build

--- a/makefile
+++ b/makefile
@@ -96,7 +96,7 @@ TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 
 .PHONY:check
 check: $(TESTOUTPUT)
-	cd test && ../$(TESTOUTPUT)
+	wine $(TESTOUTPUT)
 
 $(TESTOUTPUT): $(TESTOBJS) $(SRCOBJS)
 	@mkdir -p ${@D}

--- a/makefile
+++ b/makefile
@@ -87,7 +87,7 @@ TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(SRCDIR) -I.build/include
 TESTLDFLAGS := -L./ -L$(GTESTDIR)
-TESTLIBS := -lgtest -lgtest_main -lpthread -lstdc++fs
+TESTLIBS := -lgtest -lgtest_main -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTOBJDIR)/$*.Td

--- a/makefile
+++ b/makefile
@@ -78,7 +78,7 @@ gtest:
 
 TESTDIR := test
 TESTOBJDIR := $(BUILDDIR)/testObj
-TESTSRCS := #$(shell find $(TESTDIR) -name '*.cpp')
+TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTLDFLAGS := -L./ -L$(GTESTDIR)

--- a/makefile
+++ b/makefile
@@ -56,14 +56,9 @@ include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(DEPDIR)/%.d,$(SRCS)))
 
 .PHONY:clean, clean-deps, clean-all
 clean:
-	-rm -fr $(OBJDIR)
-	-rm -fr $(DEPDIR)
-	-rm -fr $(BINDIR)
-	-rm -f $(OUTPUT)
-clean-deps:
-	-rm -fr $(DEPDIR)
-clean-all:
 	-rm -rf $(BUILDDIR)
+clean-all: clean
+	-rm -f $(OUTPUT)
 
 
 GTESTDIR := $(BUILDDIR)/gtest

--- a/makefile
+++ b/makefile
@@ -66,7 +66,7 @@ GTESTDIR := $(BUILDDIR)/gtest
 .PHONY:gtest
 gtest:
 	mkdir -p $(GTESTDIR)
-	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" /usr/src/gtest/
+	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON /usr/src/gtest
 	make -C $(GTESTDIR)
 
 

--- a/makefile
+++ b/makefile
@@ -62,13 +62,18 @@ clean-all: clean
 	-rm -f $(OUTPUT)
 
 
+GTESTSRCDIR := /usr/src/gtest/
+GTESTINCDIR := /usr/include/gtest/
 GTESTDIR := $(BUILDDIR)/gtest
+GTESTLOCALINCDIR := $(BUILDDIR)/include/
 
 .PHONY:gtest
 gtest:
 	mkdir -p $(GTESTDIR)
-	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON /usr/src/gtest
+	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON $(GTESTSRCDIR)
 	make -C $(GTESTDIR)
+	mkdir -p $(GTESTLOCALINCDIR)
+	cp -r $(GTESTINCDIR) $(GTESTLOCALINCDIR)
 
 
 TESTDIR := test

--- a/makefile
+++ b/makefile
@@ -93,9 +93,9 @@ TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 check: $(TESTOUTPUT)
 	cd test && ../$(TESTOUTPUT)
 
-$(TESTOUTPUT): $(TESTOBJS) $(OUTPUT)
+$(TESTOUTPUT): $(TESTOBJS) $(OBJS)
 	@mkdir -p ${@D}
-	$(CXX) $(TESTOBJS) $(TESTLDFLAGS) $(TESTLIBS) -o $@
+	$(CXX) $^ $(TESTLDFLAGS) $(TESTLIBS) -o $@
 
 $(TESTOBJS): $(TESTOBJDIR)/%.o : $(TESTDIR)/%.cpp $(TESTOBJDIR)/%.d | test-build-folder
 	$(TESTCOMPILE.cpp) $(OUTPUT_OPTION) -I$(SRCDIR) $<

--- a/makefile
+++ b/makefile
@@ -81,12 +81,13 @@ TESTOBJDIR := $(BUILDDIR)/testObj
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
+TESTCPPFLAGS := -I$(SRCDIR) -I.build/include
 TESTLDFLAGS := -L./ -L$(GTESTDIR)
 TESTLIBS := -lgtest -lgtest_main -lpthread -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTOBJDIR)/$*.Td
-TESTCOMPILE.cpp = $(CXX) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
+TESTCOMPILE.cpp = $(CXX) $(TESTCPPFLAGS) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
 TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 
 .PHONY:check
@@ -98,7 +99,7 @@ $(TESTOUTPUT): $(TESTOBJS) $(OBJS)
 	$(CXX) $^ $(TESTLDFLAGS) $(TESTLIBS) -o $@
 
 $(TESTOBJS): $(TESTOBJDIR)/%.o : $(TESTDIR)/%.cpp $(TESTOBJDIR)/%.d | test-build-folder
-	$(TESTCOMPILE.cpp) $(OUTPUT_OPTION) -I$(SRCDIR) $<
+	$(TESTCOMPILE.cpp) $(OUTPUT_OPTION) $<
 	$(TESTPOSTCOMPILE)
 
 .PHONY:test-build-folder


### PR DESCRIPTION
Cleans up the Linux makefile. This solves many of the Linux issues mentioned in Issue #47 for compiling and using Google Test with MinGW. (No attempt to address the Windows side of that issue, or adding any test project or test code).

----

Some object files were filtered from inclusion with test code due to references to Outpost2DLL or `_ReturnAddress`, which currently cause link errors on LInux with Mingw. In the case of Outpost2DLL, the problem is name mangling differences. I'm uncertain of the problem with `_ReturnAddress`.

Not addresses, are installing any needed Mingw specific libraries into Wine to run the test executable.

----

Linux only changes.
