### PR TITLE
Map _ReturnAddress to GCC built-in

### DIFF
--- a/makefile
+++ b/makefile
@@ -77,7 +77,7 @@ gtest:
 
 
 # Objects with references to Outpost2DLL or _ReturnAddress are a problem for the linker
-OBJSWITHREFS := $(OBJDIR)/DllMain.o $(OBJDIR)/IpDropDown.o $(OBJDIR)/op2ext.o
+OBJSWITHREFS := $(OBJDIR)/DllMain.o $(OBJDIR)/IpDropDown.o
 SRCOBJS := $(filter-out $(OBJSWITHREFS),$(OBJS)) # Remove objects with problem references
 
 TESTDIR := test

--- a/op2ext.cpp
+++ b/op2ext.cpp
@@ -9,6 +9,7 @@
 #include <windows.h>
 #include <intrin.h> // _ReturnAddress
 
+#pragma intrinsic(_ReturnAddress)
 #ifdef __MINGW32__
 #define _ReturnAddress() __builtin_return_address(0)
 #endif

--- a/op2ext.cpp
+++ b/op2ext.cpp
@@ -9,6 +9,10 @@
 #include <windows.h>
 #include <intrin.h> // _ReturnAddress
 
+#ifdef __MINGW32__
+#define _ReturnAddress() __builtin_return_address(0)
+#endif
+
 
 size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, size_t bufferSize);
 


### PR DESCRIPTION
This works around a linker error seen when compiling with Mingw:
```
.build/obj/op2ext.o: In function `Log':
/home/dstevens/code/opu/NetFixClient/op2ext/op2ext.cpp:110: undefined reference to `_ReturnAddress'
```

I thought I read somewhere that Mingw had built in support to map `_ReturnAddress` to the GCC built-in `__builtin_return_address(0)`, but that hasn't been working for me. Perhaps the change is in a newer version.

For reference, I was using:
```
mingw --version
i686-w64-mingw32-g++ (GCC) 7.3-win32 20180312
```

----

For reference:
https://docs.microsoft.com/en-us/cpp/intrinsics/returnaddress?view=vs-2017
https://gcc.gnu.org/onlinedocs/gcc/Return-Address.html
