### PR TITLE
Statically link mingw libraries

### DIFF
--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ OUTPUT := op2ext.dll
 
 CPPFLAGS := -DOP2EXT_INTERNAL_BUILD
 CXXFLAGS := -std=c++17 -g -Wall -Wno-unknown-pragmas
-LDFLAGS := -shared -LSubmodules/Outpost2DLL/Lib/
+LDFLAGS := -shared -static-libgcc -static-libstdc++ -LSubmodules/Outpost2DLL/Lib/
 LDLIBS := -lOutpost2DLL -lstdc++fs -lws2_32
 
 DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPDIR)/$*.Td

--- a/makefile
+++ b/makefile
@@ -86,7 +86,7 @@ TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(SRCDIR) -I.build/include
-TESTLDFLAGS := -L./ -L$(GTESTDIR)
+TESTLDFLAGS := -static-libgcc -static-libstdc++ -L./ -L$(GTESTDIR)
 TESTLIBS := -lgtest -lgtest_main -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 


### PR DESCRIPTION
This was the last part needed to get GTest test code to run on Wine after being compiled with Mingw. (See PR #48 for other changes).

Adding `-static-libgcc` and `-static-libstdc++` will statically link the C/C++ Runtime libraries, rather than use dynamic linking. This eliminates the following two errors about missing `libgcc_s_sjlj-1.dll` (C Runtime) and missing `libstdc++-6.dll` (C++ Runtime) DLLs.

Loader errors (edited for paths):
```
0009:err:module:import_dll Library libgcc_s_sjlj-1.dll (which is needed by L"...\\NetFixClient\\op2ext\\.build\\testBin\\runTests") not found
0009:err:module:import_dll Library libstdc++-6.dll (which is needed by L"...\\NetFixClient\\op2ext\\.build\\testBin\\runTests") not found
```

----

Linux only change.
