### PR TITLE
Set output filename to op2ext.dll

### DIFF
--- a/srcDLL/op2extDLL.vcxproj
+++ b/srcDLL/op2extDLL.vcxproj
@@ -43,9 +43,11 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <TargetName>op2ext</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>false</LinkIncremental>
+    <TargetName>op2ext</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>


### PR DESCRIPTION
Now that it is built from op2extDLL project, the default filename is op2extDLL.dll and must be manually configured.

I missed this detail earlier because I didn't manually delete op2ext.dll from Outpost2Path's location. So both an op2ext.dll and a op2extDLL.dll existed. The older op2ext.dll must have initially worked okay for my test to make sure the game used the module loader. Sometime after the initial test, things went south. This also prevented the debugger from finding the correct file and symbols.