### PR TITLE
Update test project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 Debug/
 Release/
-Outpost2/
+packages/
 .vs/
 .build/
 *.suo

--- a/TestModule/CountFilesByTypeInDirectory.cpp
+++ b/TestModule/CountFilesByTypeInDirectory.cpp
@@ -1,9 +1,9 @@
 #include "CountFilesByTypeInDirectory.h"
 #include <string>
 #include <algorithm>
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 void ToLowerInPlace(std::string& x) {
 	std::transform(x.begin(), x.end(), x.begin(), ::tolower);

--- a/TestModule/CountFilesByTypeInDirectory.cpp
+++ b/TestModule/CountFilesByTypeInDirectory.cpp
@@ -1,9 +1,8 @@
 #include "CountFilesByTypeInDirectory.h"
+#include "../srcStatic/FileSystemHelper.h"
 #include <string>
 #include <algorithm>
-#include <filesystem>
 
-namespace fs = std::filesystem;
 
 void ToLowerInPlace(std::string& x) {
 	std::transform(x.begin(), x.end(), x.begin(), ::tolower);

--- a/TestModule/TestModule.vcxproj
+++ b/TestModule/TestModule.vcxproj
@@ -54,6 +54,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../srcDLL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
@@ -77,6 +78,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>../srcDLL;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -7,10 +7,10 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <algorithm>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 
 void LocateVolFiles(std::string relativeDirectory = "");

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -7,10 +7,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
-#include <filesystem>
 #include <algorithm>
-
-namespace fs = std::filesystem;
 
 
 void LocateVolFiles(std::string relativeDirectory = "");

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -99,3 +99,8 @@ OP2EXT_API void Log(const char* message)
 
 	logger.Log(message, FindModuleName(_ReturnAddress()));
 }
+
+OP2EXT_API bool IsConsoleModuleLoaded(const char* moduleName)
+{
+	return consoleModLoader.IsModuleLoaded(moduleName);
+}

--- a/srcDLL/op2ext.h
+++ b/srcDLL/op2ext.h
@@ -18,7 +18,7 @@ extern "C" {
 #endif
 
 #include <stddef.h> // size_t (C specific variant)
-
+#include <stdbool.h> // C specific typedefs for bool, true, false
 
 // Retrieves the current absolute directory of the Outpost 2 executable with a trailing slash.
 // If bufferSize is smaller than required to copy entire path, buffer is provided as much of path as possible.
@@ -58,6 +58,10 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch);
 
 // Log a message in Outpost2Log.txt.
 OP2EXT_API void Log(const char* message);
+
+// Performs a case insensitive comparison of the loaded console module name.
+// A console module's name is the name of the directory the console module is stored in.
+OP2EXT_API bool IsConsoleModuleLoaded(const char* moduleName);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -17,9 +17,26 @@ ConsoleModuleLoader::ConsoleModuleLoader()
 	moduleDirectory = FindModuleDirectory();
 }
 
+ConsoleModuleLoader::ConsoleModuleLoader(const std::string& testModuleDirectory)
+{
+	OutputDebugString("Console Module constructed in test mode.");
+
+	moduleDirectory = testModuleDirectory;
+}
+
 std::string ConsoleModuleLoader::GetModuleDirectory()
 {
 	return moduleDirectory;
+}
+
+std::string ConsoleModuleLoader::GetModuleName()
+{
+	return ToLower(moduleDirectory);
+}
+
+bool ConsoleModuleLoader::IsModuleLoaded(std::string moduleName)
+{
+	return ToLowerInPlace(moduleName) == GetModuleName();
 }
 
 int __fastcall GetArtPath(void*, int, char*, char*, char *destBuffer, int bufferSize, char *defaultValue)

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -7,11 +7,8 @@
 #include <sstream>
 #include <algorithm>
 #include <iterator>
-#include <filesystem>
 #include <stdexcept>
 #include <cstddef>
-
-namespace fs = std::filesystem;
 
 std::string moduleDirectory;
 

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -7,11 +7,11 @@
 #include <sstream>
 #include <algorithm>
 #include <iterator>
-#include <experimental/filesystem>
+#include <filesystem>
 #include <stdexcept>
 #include <cstddef>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 std::string moduleDirectory;
 

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -1,15 +1,18 @@
 #include <windows.h>
-
 #include <string>
 #include <vector>
 
 class ConsoleModuleLoader {
 public:
 	ConsoleModuleLoader();
+	// Test Constructor
+	ConsoleModuleLoader(const std::string& testModuleDirectory);
 	void LoadModule();
 	void UnloadModule();
 	void RunModule();
 	std::string GetModuleDirectory();
+	std::string GetModuleName();
+	bool IsModuleLoaded(std::string moduleName);
 
 private:
 	HINSTANCE modDllHandle = nullptr;

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -1,3 +1,4 @@
+#include "FileSystemHelper.h"
 #include "GlobalDefines.h"
 
 #define WIN32_LEAN_AND_MEAN

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -4,9 +4,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <cstddef>
-#include <filesystem>
 
-namespace fs = std::filesystem;
 
 std::string GetPrivateProfileStdString(std::string sectionName, std::string key, std::string filename);
 

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -3,9 +3,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <cstddef>
-#include <experimental/filesystem>
+#include <filesystem>
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::filesystem;
 
 std::string GetPrivateProfileStdString(std::string sectionName, std::string key, std::string filename);
 

--- a/srcStatic/FileSystemHelper.h
+++ b/srcStatic/FileSystemHelper.h
@@ -1,5 +1,13 @@
 #include <string>
 
+#ifdef __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
+
 std::string GetGameDirectory();
 std::string GetOutpost2IniPath();
 std::string GetOP2PrivateProfileString(std::string sectionName, std::string key);

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -1,4 +1,5 @@
 #include "StringConversion.h"
+#include <algorithm>
 
 std::string ConvertLpctstrToString(LPCSTR str)
 {
@@ -46,4 +47,16 @@ std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* b
 	}
 	// Unable to copy the whole string, so return needed buffer size
 	return stringToCopy.size() + 1;
+}
+
+std::string& ToLowerInPlace(std::string& x) {
+	std::transform(x.begin(), x.end(), x.begin(), ::tolower);
+
+	return x;
+}
+
+std::string ToLower(std::string x) {
+	std::transform(x.begin(), x.end(), x.begin(), ::tolower);
+
+	return x;
 }

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -15,3 +15,9 @@ std::string ConvertLpctstrToString(LPCSTR str);
 // Returns 0 on success
 // Returns needed buffer size (including space for null terminator) if the destination buffer is too small
 std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize);
+
+// Converts all characters in string lower case
+std::string& ToLowerInPlace(std::string& x);
+
+// Returns a new string where all characters have been converted to lower case
+std::string ToLower(std::string x);

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -1,0 +1,33 @@
+#include "ConsoleModuleLoader.h"
+#include <gtest/gtest.h>
+#include <string>
+
+
+TEST(ConsoleModuleLoader, NoModuleLoaded)
+{
+	ConsoleModuleLoader consoleModLoader;
+
+	// Returns empty string if no module available
+	EXPECT_EQ("", consoleModLoader.GetModuleName());
+
+	EXPECT_TRUE(consoleModLoader.IsModuleLoaded(""));
+	EXPECT_FALSE(consoleModLoader.IsModuleLoaded("TEST"));
+}
+
+TEST(ConsoleModuleLoader, GetModuleDirectory)
+{
+	const std::string testModule("TestModule");
+	ConsoleModuleLoader consoleModLoader(testModule);
+
+	EXPECT_NE("", consoleModLoader.GetModuleDirectory());
+	EXPECT_EQ(testModule, consoleModLoader.GetModuleDirectory());
+}
+
+TEST(ConsoleModuleLoader, GetModuleName)
+{
+	const std::string testModule("testmodule");
+	ConsoleModuleLoader consoleModLoader(testModule);
+
+	EXPECT_NE("", consoleModLoader.GetModuleName());
+	EXPECT_EQ(testModule, consoleModLoader.GetModuleName());
+}

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -1,0 +1,19 @@
+#include "StringConversion.h"
+#include <gtest/gtest.h>
+#include <string>
+
+TEST(StringConversion, ToLower)
+{
+	EXPECT_EQ("test", ToLower("TEST"));
+	EXPECT_EQ("", ToLower(""));
+}
+
+TEST(StringConversion, ToLowerInPlace)
+{
+	std::string str("TEST");
+	EXPECT_EQ("test", ToLowerInPlace(str));
+
+	// Test Empty string
+	str = "";
+	EXPECT_EQ("", ToLowerInPlace(str));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -48,6 +48,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -61,6 +62,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -25,7 +25,9 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClCompile Include="ConsolueModuleLoader.test.cpp" />
     <ClCompile Include="op2ext.test.cpp" />
+    <ClCompile Include="StringConversion.test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\srcStatic\op2extStatic.vcxproj">

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -48,7 +48,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -62,7 +61,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <DisableSpecificWarnings>4996</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
There is an intention to compile using mingw. Not sure if we can remove the experimental includes for filesystem and accomplish this. If not, it will be easy to add a preprocessor directive to detect.

The static project was already setup to use C++17. I noticed the newer version of the gtest nuget package was already in use.

This branch re-enables 4996 warnings on the test project sense the newer 1.8.1 nuget gtest package no longer produces them.