### PR TITLE
Expand `ToLowerInPlace` unit tests

### DIFF
--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -12,8 +12,10 @@ TEST(StringConversion, ToLowerInPlace)
 {
 	std::string str("TEST");
 	EXPECT_EQ("test", ToLowerInPlace(str));
+	EXPECT_EQ("test", str);
 
 	// Test Empty string
 	str = "";
 	EXPECT_EQ("", ToLowerInPlace(str));
+	EXPECT_EQ("", str);
 }


### PR DESCRIPTION
This is a post merge patch for PR #71.

The expanded test is to ensure the originally passed variable is indeed modified in place. Without this check, the implementation of `ToLower` would allow the test to pass, even though `ToLowerInPlace` has different behavior.
