### PR TITLE
Remove relative include for FilesystemHelper.h

### DIFF
--- a/TestModule/CountFilesByTypeInDirectory.cpp
+++ b/TestModule/CountFilesByTypeInDirectory.cpp
@@ -1,7 +1,14 @@
 #include "CountFilesByTypeInDirectory.h"
-#include "../srcStatic/FileSystemHelper.h"
 #include <string>
 #include <algorithm>
+
+#ifdef __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif
 
 
 void ToLowerInPlace(std::string& x) {


### PR DESCRIPTION
This avoids setting a dependency between the test module and the static library project. Ideally the test module should only depend on the DLL project.

This is a post merge update for PR #70.
