### PR TITLE
Finalize module presence public interface

### DIFF
--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -99,6 +99,12 @@ OP2EXT_API void Log(const char* message)
 	logger.Log(message, FindModuleName(_ReturnAddress()));
 }
 
+
+OP2EXT_API bool IsModuleLoaded(const char* moduleName)
+{
+	return IsConsoleModuleLoaded(moduleName) || IsIniModuleLoaded(moduleName);
+}
+
 OP2EXT_API bool IsConsoleModuleLoaded(const char* moduleName)
 {
 	return consoleModLoader.IsModuleLoaded(moduleName);

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -119,3 +119,22 @@ OP2EXT_API size_t GetLoadedModuleCount()
 {
 	return iniModuleLoader.Count() + consoleModLoader.Count();
 }
+
+OP2EXT_API size_t GetLoadedModuleName(size_t moduleIndex, char* buffer, size_t bufferSize)
+{
+	// Ini modules are indexed first and console module is last
+
+	std::string moduleName;
+
+	if (moduleIndex < iniModuleLoader.Count()) {
+		moduleName = iniModuleLoader.GetModuleName(moduleIndex);
+	}
+	else if (moduleIndex < GetLoadedModuleCount()) {
+		moduleName = consoleModLoader.GetModuleName();
+	}
+	else {
+		moduleName = "";
+	}
+
+	return CopyStdStringIntoCharBuffer(moduleName, buffer, bufferSize);
+}

--- a/srcDLL/op2ext.h
+++ b/srcDLL/op2ext.h
@@ -60,6 +60,11 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch);
 OP2EXT_API void Log(const char* message);
 
 
+// Performs a case insensitive search of loaded module names, returning true if found.
+// A console module's name is the name of the directory the console module is stored in.
+// An ini module name is the module's [section name] within the ini file.
+OP2EXT_API bool IsModuleLoaded(const char* moduleName);
+
 // Performs a case insensitive comparison of the loaded console module name.
 // A console module's name is the name of the directory the console module is stored in.
 // Returns false if passed an empty string (Module name cannot be empty).

--- a/srcDLL/op2ext.h
+++ b/srcDLL/op2ext.h
@@ -77,6 +77,15 @@ OP2EXT_API bool IsIniModuleLoaded(const char* moduleName);
 // Returns the number of loaded modules (.ini and console combined)
 OP2EXT_API size_t GetLoadedModuleCount();
 
+// Retrieves the module name at the specified index. 
+// Ini modules are indexed first and console module is last.
+// Use function GetLoadedModuleCount to determine how many module names to check. 
+// A console module's name is the name of the directory the console module is stored in.
+// An ini module name is the module's [section name] within the ini file.
+// Returns 0 on success. Returns the required minimum size of the buffer on failure.
+// If an index beyond the loaded module count is passed, returns 0 and clears the buffer.
+OP2EXT_API size_t GetLoadedModuleName(size_t moduleIndex, char* buffer, size_t bufferSize);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
Not sure if it is too confusing how GetModuleName works (indexes ini modules first, then the console module).

Alternate implementation would be to have 2 functions, one that gets the name of the console module (if loaded), and one that gets the name of a ini module.

-Brett