### PR TITLE
Update makefile testing

### DIFF
--- a/makefile
+++ b/makefile
@@ -73,7 +73,7 @@ $(DEPDIR)/%.d: ;
 
 include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(DEPDIR)/%.d,$(SRCS)))
 
-.PHONY: clean clean-deps clean-all
+.PHONY: clean clean-all
 clean:
 	-rm -rf $(BUILDDIR)
 clean-all: clean

--- a/makefile
+++ b/makefile
@@ -75,9 +75,9 @@ include $(wildcard $(patsubst $(SRCDIR)/%.cpp,$(DEPDIR)/%.d,$(SRCS)))
 
 .PHONY: clean clean-all
 clean:
-	-rm -rf $(BUILDDIR)
+	-rm -rf "$(BUILDDIR)"
 clean-all: clean
-	-rm -f $(OUTPUT)
+	-rm -f "$(OUTPUT)"
 
 
 GTESTSRCDIR := /usr/src/gtest/

--- a/makefile
+++ b/makefile
@@ -80,8 +80,8 @@ clean-all: clean
 	-rm -f "$(OUTPUT)"
 
 
-GTESTSRCDIR := /usr/src/gtest/
-GTESTINCDIR := /usr/include/gtest/
+GTESTSRCDIR := /usr/src/googletest/googletest/
+GTESTINCDIR := /usr/src/googletest/googletest/include/gtest/
 GTESTDIR := $(BUILDDIR)/gtest
 GTESTLOCALINCDIR := $(BUILDDIR)/include/
 

--- a/makefile
+++ b/makefile
@@ -80,15 +80,21 @@ clean-all: clean
 	-rm -f "$(OUTPUT)"
 
 
-GTESTSRCDIR := /usr/src/googletest/googletest/
+GTESTSRCDIR := /usr/src/googletest/
 GTESTINCDIR := /usr/src/googletest/googletest/include/
 GTESTBUILDDIR := $(BUILDDIR)/gtest/
+GTESTLIBDIR := /usr/i686-w64-mingw32/lib/
 
-.PHONY: gtest
+.PHONY: gtest gtest-install gtest-clean
 gtest:
 	mkdir -p $(GTESTBUILDDIR)
 	cd $(GTESTBUILDDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON $(GTESTSRCDIR)
 	make -C $(GTESTBUILDDIR)
+gtest-install:
+	cp $(GTESTBUILDDIR)googlemock/gtest/lib*.a $(GTESTLIBDIR)
+	cp $(GTESTBUILDDIR)googlemock/lib*.a $(GTESTLIBDIR)
+gtest-clean:
+	rm -rf $(GTESTBUILDDIR)
 
 
 # Objects with references to Outpost2DLL or _ReturnAddress are a problem for the linker
@@ -101,7 +107,7 @@ TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(SRCDIR) -I$(GTESTINCDIR)
-TESTLDFLAGS := -static-libgcc -static-libstdc++ -L./ -L$(GTESTBUILDDIR)
+TESTLDFLAGS := -static-libgcc -static-libstdc++ -L./ -L$(GTESTBUILDDIR)googlemock/ -L$(GTESTBUILDDIR)googlemock/gtest/
 TESTLIBS := -lgtest -lgtest_main -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 

--- a/makefile
+++ b/makefile
@@ -115,8 +115,9 @@ TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTOBJDIR)/$*.Td
 TESTCOMPILE.cpp = $(CXX) $(TESTCPPFLAGS) $(TESTDEPFLAGS) $(CXXFLAGS) $(TARGET_ARCH) -c
 TESTPOSTCOMPILE = @mv -f $(TESTOBJDIR)/$*.Td $(TESTOBJDIR)/$*.d && touch $@
 
-.PHONY: check
-check: $(TESTOUTPUT)
+.PHONY: test check
+test: $(TESTOUTPUT)
+check: | test
 	wine $(TESTOUTPUT)
 
 $(TESTOUTPUT): $(TESTOBJS) $(SRCOBJS)

--- a/makefile
+++ b/makefile
@@ -82,13 +82,13 @@ clean-all: clean
 
 GTESTSRCDIR := /usr/src/googletest/googletest/
 GTESTINCDIR := /usr/src/googletest/googletest/include/
-GTESTDIR := $(BUILDDIR)/gtest
+GTESTBUILDDIR := $(BUILDDIR)/gtest/
 
 .PHONY: gtest
 gtest:
-	mkdir -p $(GTESTDIR)
-	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON $(GTESTSRCDIR)
-	make -C $(GTESTDIR)
+	mkdir -p $(GTESTBUILDDIR)
+	cd $(GTESTBUILDDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON $(GTESTSRCDIR)
+	make -C $(GTESTBUILDDIR)
 
 
 # Objects with references to Outpost2DLL or _ReturnAddress are a problem for the linker
@@ -101,7 +101,7 @@ TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(SRCDIR) -I$(GTESTINCDIR)
-TESTLDFLAGS := -static-libgcc -static-libstdc++ -L./ -L$(GTESTDIR)
+TESTLDFLAGS := -static-libgcc -static-libstdc++ -L./ -L$(GTESTBUILDDIR)
 TESTLIBS := -lgtest -lgtest_main -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 

--- a/makefile
+++ b/makefile
@@ -87,14 +87,14 @@ GTESTLIBDIR := /usr/i686-w64-mingw32/lib/
 
 .PHONY: gtest gtest-install gtest-clean
 gtest:
-	mkdir -p $(GTESTBUILDDIR)
-	cd $(GTESTBUILDDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON $(GTESTSRCDIR)
-	make -C $(GTESTBUILDDIR)
+	mkdir -p "$(GTESTBUILDDIR)"
+	cd "$(GTESTBUILDDIR)" && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON "$(GTESTSRCDIR)"
+	make -C "$(GTESTBUILDDIR)"
 gtest-install:
-	cp $(GTESTBUILDDIR)googlemock/gtest/lib*.a $(GTESTLIBDIR)
-	cp $(GTESTBUILDDIR)googlemock/lib*.a $(GTESTLIBDIR)
+	cp $(GTESTBUILDDIR)googlemock/gtest/lib*.a "$(GTESTLIBDIR)"
+	cp $(GTESTBUILDDIR)googlemock/lib*.a "$(GTESTLIBDIR)"
 gtest-clean:
-	rm -rf $(GTESTBUILDDIR)
+	rm -rf "$(GTESTBUILDDIR)"
 
 
 # Objects with references to Outpost2DLL or _ReturnAddress are a problem for the linker

--- a/makefile
+++ b/makefile
@@ -81,17 +81,14 @@ clean-all: clean
 
 
 GTESTSRCDIR := /usr/src/googletest/googletest/
-GTESTINCDIR := /usr/src/googletest/googletest/include/gtest/
+GTESTINCDIR := /usr/src/googletest/googletest/include/
 GTESTDIR := $(BUILDDIR)/gtest
-GTESTLOCALINCDIR := $(BUILDDIR)/include/
 
 .PHONY: gtest
 gtest:
 	mkdir -p $(GTESTDIR)
 	cd $(GTESTDIR) && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON $(GTESTSRCDIR)
 	make -C $(GTESTDIR)
-	mkdir -p $(GTESTLOCALINCDIR)
-	cp -r $(GTESTINCDIR) $(GTESTLOCALINCDIR)
 
 
 # Objects with references to Outpost2DLL or _ReturnAddress are a problem for the linker
@@ -103,7 +100,7 @@ TESTOBJDIR := $(BUILDDIR)/testObj
 TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
-TESTCPPFLAGS := -I$(SRCDIR) -I.build/include
+TESTCPPFLAGS := -I$(SRCDIR) -I$(GTESTINCDIR)
 TESTLDFLAGS := -static-libgcc -static-libstdc++ -L./ -L$(GTESTDIR)
 TESTLIBS := -lgtest -lgtest_main -lstdc++fs
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests


### PR DESCRIPTION
Linux only change, updating the makefile test rules.

This mainly takes advantage of the improved layout of the newer Google Test package, rather than the compatibility symlink from the old package location. The new location and layout better support use for cross platform compiles with Mingw and it's Windows includes, without conflicts with the Linux system includes.

Code is buildable with either a local Mingw build of Google Test, or with a system install of the Mingw build of Google Test using paths suitable for cross compiling.
