### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,15 +1,5 @@
-# For building on CircleCI with Google Test
-
-# Build from the root project folder with:
-#   docker build .circleci/ --tag outpostuniverse/circleci-gcc-clang-googletest
-# Push image to DockerHub with:
-#   docker login
-#   docker push outpostuniverse/circleci-gcc-clang-googletest
-
-# Run locally using the CircleCI command line interface:
-#   circleci build
-# Validate .circleci/config.yml file with:
-#   circleci config validate
+# For building and running unit tests on CircleCI
+# See makefile from project root for local usage
 
 FROM ubuntu:18.04
 

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -24,6 +24,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     mingw-w64 \
   && rm -rf /var/lib/apt/lists/*
 
+# Install wine so resulting unit test binaries can be run
+RUN dpkg --add-architecture i386 && \
+  apt-get update && apt-get install -y --no-install-recommends \
+    wine-stable \
+    wine32 \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install Google Test source package
 RUN apt-get update && apt-get install -y --no-install-recommends \
     googletest \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -1,0 +1,44 @@
+# For building on CircleCI with Google Test
+
+# Build from the root project folder with:
+#   docker build .circleci/ --tag outpostuniverse/circleci-gcc-clang-googletest
+# Push image to DockerHub with:
+#   docker login
+#   docker push outpostuniverse/circleci-gcc-clang-googletest
+
+# Run locally using the CircleCI command line interface:
+#   circleci build
+# Validate .circleci/config.yml file with:
+#   circleci config validate
+
+FROM ubuntu:18.04
+
+# Install CircleCI tools needed for primary containers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ssh \
+    tar \
+    gzip \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install gcc and clang compilers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    clang \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install Google Test (source package and build dependencies)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    cmake \
+    libgtest-dev \
+  && rm -rf /var/lib/apt/lists/*
+
+# Compile and install Google Test
+ARG gtestBuildDir=/tmp/gtest/
+RUN mkdir -p ${gtestBuildDir} && \
+  cd ${gtestBuildDir} && \
+  cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/gtest/ && \
+  make -C ${gtestBuildDir} && \
+  cp ${gtestBuildDir}lib*.a /usr/lib && \
+  rm -rf ${gtestBuildDir}

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -30,13 +30,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # Compile and install Google Test
-ARG gtestBuildDir=/tmp/gtest/
-RUN mkdir -p ${gtestBuildDir} && \
-  cd ${gtestBuildDir} && \
-  cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/gtest/ && \
-  make -C ${gtestBuildDir} && \
-  cp ${gtestBuildDir}lib*.a /usr/lib && \
-  rm -rf ${gtestBuildDir}
+WORKDIR /tmp/gtest/
+RUN cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/gtest/ && \
+  make && \
+  cp lib*.a /usr/lib && \
+  rm -rf /tmp/gtest/
+WORKDIR /
 
 # Install CircleCI tools needed for primary containers
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -50,3 +50,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gzip \
     ca-certificates \
   && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /code
+VOLUME /code
+
+CMD ["make", "--keep-going", "check"]

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -26,14 +26,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Google Test source package
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libgtest-dev \
+    googletest \
   && rm -rf /var/lib/apt/lists/*
 
 # Compile and install Google Test
 WORKDIR /tmp/gtest/
-RUN cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/gtest/ && \
+RUN cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/googletest/ && \
   make && \
-  cp lib*.a /usr/lib && \
+  cp googlemock/gtest/lib*.a /usr/lib && \
+  cp googlemock/lib*.a /usr/lib && \
   rm -rf /tmp/gtest/
 WORKDIR /
 

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -29,6 +29,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     googletest \
   && rm -rf /var/lib/apt/lists/*
 
+# Set mingw as default compiler
+ENV CXX=i686-w64-mingw32-g++
+ENV  CC=i686-w64-mingw32-gcc
+
 # Compile and install Google Test
 WORKDIR /tmp/gtest/
 RUN cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/googletest/ && \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -15,25 +15,25 @@ FROM ubuntu:18.04
 
 # Install base development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    cmake \
+    build-essential=12.4ubuntu1 \
+    cmake=3.10.2-1ubuntu2 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install mingw compiler
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    mingw-w64 \
+    mingw-w64=5.0.3-1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install wine so resulting unit test binaries can be run
 RUN dpkg --add-architecture i386 && \
   apt-get update && apt-get install -y --no-install-recommends \
-    wine-stable \
-    wine32 \
+    wine-stable=3.0-1ubuntu1 \
+    wine32=3.0-1ubuntu1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Google Test source package
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    googletest \
+    googletest=1.8.0-6 \
   && rm -rf /var/lib/apt/lists/*
 
 # Set mingw as default compiler
@@ -51,11 +51,11 @@ WORKDIR /
 
 # Install CircleCI tools needed for primary containers
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    ssh \
-    tar \
-    gzip \
-    ca-certificates \
+    git=1:2.17.1-1ubuntu0.4 \
+    ssh=1:7.6p1-4ubuntu0.3 \
+    tar=1.29b-2ubuntu0.1 \
+    gzip=1.6-5ubuntu1 \
+    ca-certificates=20180409 \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /code

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -35,10 +35,10 @@ ENV  CC=i686-w64-mingw32-gcc
 
 # Compile and install Google Test
 WORKDIR /tmp/gtest/
-RUN cmake -DCMAKE_CXX_FLAGS="-std=c++14" /usr/src/googletest/ && \
+RUN cmake -DCMAKE_CXX_FLAGS="-std=c++14" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON /usr/src/googletest/ && \
   make && \
-  cp googlemock/gtest/lib*.a /usr/lib && \
-  cp googlemock/lib*.a /usr/lib && \
+  cp googlemock/gtest/lib*.a /usr/i686-w64-mingw32/lib/ && \
+  cp googlemock/lib*.a /usr/i686-w64-mingw32/lib/ && \
   rm -rf /tmp/gtest/
 WORKDIR /
 

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -13,15 +13,14 @@
 
 FROM ubuntu:18.04
 
-# Install gcc and clang compilers
+# Install base development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
-    clang \
+    cmake \
   && rm -rf /var/lib/apt/lists/*
 
-# Install Google Test (source package and build dependencies)
+# Install Google Test source package
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    cmake \
     libgtest-dev \
   && rm -rf /var/lib/apt/lists/*
 

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -13,15 +13,6 @@
 
 FROM ubuntu:18.04
 
-# Install CircleCI tools needed for primary containers
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git \
-    ssh \
-    tar \
-    gzip \
-    ca-certificates \
-  && rm -rf /var/lib/apt/lists/*
-
 # Install gcc and clang compilers
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -42,3 +33,12 @@ RUN mkdir -p ${gtestBuildDir} && \
   make -C ${gtestBuildDir} && \
   cp ${gtestBuildDir}lib*.a /usr/lib && \
   rm -rf ${gtestBuildDir}
+
+# Install CircleCI tools needed for primary containers
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    ssh \
+    tar \
+    gzip \
+    ca-certificates \
+  && rm -rf /var/lib/apt/lists/*

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -19,6 +19,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     cmake \
   && rm -rf /var/lib/apt/lists/*
 
+# Install mingw compiler
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    mingw-w64 \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install Google Test source package
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgtest-dev \

--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -35,7 +35,7 @@ ENV  CC=i686-w64-mingw32-gcc
 
 # Compile and install Google Test
 WORKDIR /tmp/gtest/
-RUN cmake -DCMAKE_CXX_FLAGS="-std=c++14" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON /usr/src/googletest/ && \
+RUN cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON /usr/src/googletest/ && \
   make && \
   cp googlemock/gtest/lib*.a /usr/i686-w64-mingw32/lib/ && \
   cp googlemock/lib*.a /usr/i686-w64-mingw32/lib/ && \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,10 @@ version: 2
 jobs:
   build:
     docker:
-      - image: outpostuniverse/circleci-gcc-googletest
+      - image: outpostuniverse/gcc-mingw-wine-googletest-circleci:1.2
     steps:
       - checkout
       - run: git submodule update --init
-#      - run: make -k CXX=g++
-#      - run: make check CXX=g++
+      - run: make --keep-going
+      - run: make --keep-going test
+      - run: make --keep-going check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ jobs:
     docker:
       - image: outpostuniverse/gcc-mingw-wine-googletest-circleci:1.2
     steps:
+      - run: WINEARCH=win32 winecfg
       - checkout
       - run: git submodule update --init
       - run: make --keep-going

--- a/makefile
+++ b/makefile
@@ -136,3 +136,24 @@ $(TESTOBJDIR)/%.d: ;
 .PRECIOUS: $(TESTOBJDIR)/%.d
 
 include $(wildcard $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.d,$(TESTSRCS)))
+
+
+# Docker commands
+
+.PHONY: docker-build-image docker-push
+
+docker-build-image:
+	docker build .circleci/ --tag outpostuniverse/gcc-mingw-wine-googletest-circleci:latest --tag outpostuniverse/gcc-mingw-wine-googletest-circleci:1.2
+docker-push:
+	docker login
+	docker push outpostuniverse/gcc-mingw-wine-googletest-circleci
+
+
+# CircleCI commands
+
+.PHONY: circleci-build circleci-validate
+
+circleci-build:
+	circleci build
+circleci-validate:
+	circleci config validate


### PR DESCRIPTION
This adds a Dockerfile with Mingw and Wine, suitable for doing cross compiles from Linux to Windows, and running the resulting binaries. It then adds CircleCI config which uses this Dockerfile to compile the Windows only op2ext project and run unit tests, all from Linux.

Closes #68.
