### PR TITLE
Restore master branch to a working state

### DIFF
--- a/srcStatic/FileSystemHelper.h
+++ b/srcStatic/FileSystemHelper.h
@@ -1,12 +1,12 @@
 #include <string>
 
-#ifdef __cpp_lib_filesystem
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
+//#ifdef __cpp_lib_filesystem
+//#include <filesystem>
+//namespace fs = std::filesystem;
+//#else
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
-#endif
+//#endif
 
 std::string GetGameDirectory();
 std::string GetOutpost2IniPath();


### PR DESCRIPTION
Test Module's filesystem call and directory_iterator call do not cause the exception.

This branch will get the master working without crashing Outpost 2 for the short term.