### PR TITLE
Ignore failures for submodule update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - run: WINEARCH=win32 winecfg
       - checkout
-      - run: git submodule update --init
+      - run: git submodule update --init || true
       - run: make --keep-going
       - run: make --keep-going test
       - run: make --keep-going check


### PR DESCRIPTION
This prevents failures from terminating a build early when running locally with the `circleci` command line tool.

When run locally, the `circleci` tool copies the repository root into the build image, rather than doing a usual git clone. This allows uncommitted changes to be built and run in the test environment.

One caveat of the local copy is how it uses the parent folder of the `.circleci/` folder as the project root. In the case of NetFixClient, there is a larger repository containing the op2ext repository, and the larger NetFixClient repository is not copied into the build image when building just the op2ext part.

With Git, submodule information is stored in the parent repository's `.git/` folder. Intermediate projects, such as op2ext have a `.git` file, with a relative path referencing the parent repository's `.git/` folder. They do not directly contain information for their own submodules, as that is stored in the parent repository's folder.

Due to the nature of the partial copy done by the `circleci` command line tool, and the nature of Git submodule information storage, the `git submodule update --init` command will fail within the CircleCI Docker image, as it references the parent repository's `.git/` folder, which was not copied into the image. In the end, this doesn't really matter, as the folder copy done by the `circleci` tool will copy all the subfolders, including the `Outpost2DLL/` submodule folder, hence it should already be there, without needing to run a `git submodule update --init`.

----

```
NetFixClient/     # Top-level ".git/" folder with submodule info for all sub-projects
  OP2Internal/
  op2ext/         # Copied
    Outpost2DLL/  # Copied
```
