### PR TITLE
Improve console module loader testability

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -50,7 +50,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 		SetLoadOffset();
 
 		// Replace call to gTApp.Init with custom routine
-		Op2MemSetDword(tAppInitCallAddr, tAppInitNewAddr - (loadOffset + (DWORD)tAppInitCallAddr + sizeof(void*)));
+		Op2MemSetDword(tAppInitCallAddr, tAppInitNewAddr - (GetLoadOffset() + (DWORD)tAppInitCallAddr + sizeof(void*)));
 
 		// Disable any more thread attach calls
 		DisableThreadLibraryCalls(hInstance);
@@ -64,7 +64,7 @@ int __fastcall ExtInit(TApp *thisPtr, int)
 	DWORD ignoredAttr;
 
 	// Set the execute flag on the DSEG section so DEP doesn't terminate the game
-	VirtualProtect((void*)(loadOffset + 0x00585000), 0x00587000 - 0x00585000, PAGE_EXECUTE_READWRITE, &ignoredAttr);
+	VirtualProtect((void*)(GetLoadOffset() + 0x00585000), 0x00587000 - 0x00585000, PAGE_EXECUTE_READWRITE, &ignoredAttr);
 
 	InstallIpDropDown();
 
@@ -86,7 +86,7 @@ int __fastcall ExtInit(TApp *thisPtr, int)
 	Op2MemSetDword(loadLibraryDataAddr, (int)&loadLibraryNewAddr);
 
 	// Replace call to gTApp.ShutDown with custom routine
-	Op2MemSetDword(tAppShutDownCallAddr, tAppShutDownNewAddr - (loadOffset + (DWORD)tAppShutDownCallAddr + sizeof(void*)));
+	Op2MemSetDword(tAppShutDownCallAddr, tAppShutDownNewAddr - (GetLoadOffset() + (DWORD)tAppShutDownCallAddr + sizeof(void*)));
 
 	// Call original function
 	return thisPtr->Init();

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -60,7 +60,7 @@ OP2EXT_API char* GetCurrentModDir()
 OP2EXT_API void AddVolToList(const char* volFilename)
 {
 	if (modulesRunning) {
-		PostErrorMessage("op2ext.cpp", __LINE__, "VOLs may not be added to the list after game startup.");
+		PostErrorMessage(__FILE__, __LINE__, "VOLs may not be added to the list after game startup.");
 	}
 	else {
 		volList.AddVolFile(volFilename);
@@ -71,7 +71,7 @@ char* multiplayerVersionStringAddress = (char*)0x004E973C;
 OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 {
 	if (modulesRunning || major < 0 || major > 9 || minor < 0 || minor > 9 || patch < 0 || patch > 9) {
-		PostErrorMessage("op2ext.cpp", __LINE__, "SetSerialNumber failed. Invalid mod serial number or was called after game startup.");
+		PostErrorMessage(__FILE__, __LINE__, "SetSerialNumber failed. Invalid mod serial number or was called after game startup.");
 	}
 	else {
 		char buffer[8];

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -14,7 +14,7 @@ std::string ParseLoadModCommand(std::vector<std::string> arguments);
 std::string FormModRelativeDirectory(std::vector<std::string> arguments);
 
 
-std::string ParseCommandLine()
+std::string FindModuleDirectory()
 {
 	auto arguments = GetCommandLineArguments();
 

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -1,0 +1,123 @@
+#include "ConsoleArgumentParser.h"
+#include "StringConversion.h"
+#include "FileSystemHelper.h"
+#include "GlobalDefines.h"
+#include <windows.h> // Cannot use WIN32_LEAN_AND_MEAN (it does not contain CommandLineToArgvW)
+#include <system_error>
+#include <vector>
+
+
+std::vector<std::string> GetCommandLineArguments();
+std::string GetSwitch(std::vector<std::string>& arguments);
+std::string ParseSwitchName(std::string switchName);
+std::string ParseLoadModCommand(std::vector<std::string> arguments);
+std::string FormModRelativeDirectory(std::vector<std::string> arguments);
+
+
+std::string ParseCommandLine()
+{
+	auto arguments = GetCommandLineArguments();
+
+	const std::string switchName = GetSwitch(arguments);
+
+	if (switchName.empty()) {
+		return std::string();
+	}
+
+	if (switchName == "loadmod") {
+		return ParseLoadModCommand(arguments);
+	}
+
+	PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Provided switch is not supported: " + switchName);
+	return std::string();
+}
+
+std::vector<std::string> GetCommandLineArguments()
+{
+	std::vector<std::string> arguments;
+	int argumentCount;
+	LPWSTR* commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
+
+	if (commandLineArgs == nullptr) {
+		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
+	}
+	else {
+		try {
+			// Ignore the first argument, which is the path of the executable.
+			for (int i = 1; i < argumentCount; ++i) {
+				std::string argument;
+				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
+					PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to cast the " + std::to_string(i) +
+						" command line argument from LPWSTR to char*. Further parsing of command line arguments aborted.");
+					break;
+				}
+				arguments.push_back(argument);
+			}
+		}
+		// Catch STL produced exceptions
+		catch (const std::exception& e) {
+			PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Error occurred attempting to parse command line arguments. Further parshing of command line arguments aborted. Internal Error: " + std::string(e.what()));
+		}
+	}
+
+	LocalFree(commandLineArgs);
+	return arguments;
+}
+
+std::string GetSwitch(std::vector<std::string>& arguments)
+{
+	if (arguments.size() == 0) {
+		return std::string(); // Switch is not present
+	}
+
+	const std::string rawSwitch = arguments[0];
+	arguments.erase(arguments.begin()); // Remove rawSwitch from arguments
+
+	return ParseSwitchName(rawSwitch);
+}
+
+// Returns empty string on failure
+std::string ParseSwitchName(std::string switchName)
+{
+	if (switchName[0] != '/' && switchName[0] != '-') {
+		const std::string message("A switch was expected but not found. Prefix switch name with '/' or '-'. The following statement was found instead: " + switchName);
+		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, message);
+		return std::string();
+	}
+
+	switchName.erase(switchName.begin(), switchName.begin() + 1); //Removes leading - or /
+	ToLowerInPlace(switchName);
+
+	return switchName;
+}
+
+std::string ParseLoadModCommand(std::vector<std::string> arguments)
+{
+	if (arguments.empty()) {
+		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "No relative directory argument provided for the switch loadmod");
+		return std::string();
+	}
+
+	try {
+		return FormModRelativeDirectory(arguments);
+	}
+	catch (const std::exception& e) {
+		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to parse module directory. " + std::string(e.what()));
+		return std::string();
+	}
+}
+
+std::string FormModRelativeDirectory(std::vector<std::string> arguments)
+{
+	std::string modRelativeDirectory;
+
+	for (std::size_t i = 0; i < arguments.size(); ++i) {
+		modRelativeDirectory += arguments[i];
+
+		if (i < arguments.size() - 1) {
+			modRelativeDirectory += " ";
+		}
+	}
+
+	return modRelativeDirectory;
+}

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -28,7 +28,7 @@ std::string ParseCommandLine()
 		return ParseLoadModCommand(arguments);
 	}
 
-	PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Provided switch is not supported: " + switchName);
+	PostErrorMessage(__FILE__, __LINE__, "Provided switch is not supported: " + switchName);
 	return std::string();
 }
 
@@ -39,7 +39,7 @@ std::vector<std::string> GetCommandLineArguments()
 	LPWSTR* commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
 
 	if (commandLineArgs == nullptr) {
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
+		PostErrorMessage(__FILE__, __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
 	}
 	else {
 		try {
@@ -47,7 +47,7 @@ std::vector<std::string> GetCommandLineArguments()
 			for (int i = 1; i < argumentCount; ++i) {
 				std::string argument;
 				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
-					PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to cast the " + std::to_string(i) +
+					PostErrorMessage(__FILE__, __LINE__, "Unable to cast the " + std::to_string(i) +
 						" command line argument from LPWSTR to char*. Further parsing of command line arguments aborted.");
 					break;
 				}
@@ -56,7 +56,7 @@ std::vector<std::string> GetCommandLineArguments()
 		}
 		// Catch STL produced exceptions
 		catch (const std::exception& e) {
-			PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Error occurred attempting to parse command line arguments. Further parshing of command line arguments aborted. Internal Error: " + std::string(e.what()));
+			PostErrorMessage(__FILE__, __LINE__, "Error occurred attempting to parse command line arguments. Further parshing of command line arguments aborted. Internal Error: " + std::string(e.what()));
 		}
 	}
 
@@ -81,7 +81,7 @@ std::string ParseSwitchName(std::string switchName)
 {
 	if (switchName[0] != '/' && switchName[0] != '-') {
 		const std::string message("A switch was expected but not found. Prefix switch name with '/' or '-'. The following statement was found instead: " + switchName);
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, message);
+		PostErrorMessage(__FILE__, __LINE__, message);
 		return std::string();
 	}
 
@@ -94,7 +94,7 @@ std::string ParseSwitchName(std::string switchName)
 std::string ParseLoadModCommand(std::vector<std::string> arguments)
 {
 	if (arguments.empty()) {
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "No relative directory argument provided for the switch loadmod");
+		PostErrorMessage(__FILE__, __LINE__, "No relative directory argument provided for the switch loadmod");
 		return std::string();
 	}
 
@@ -102,7 +102,7 @@ std::string ParseLoadModCommand(std::vector<std::string> arguments)
 		return FormModRelativeDirectory(arguments);
 	}
 	catch (const std::exception& e) {
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to parse module directory. " + std::string(e.what()));
+		PostErrorMessage(__FILE__, __LINE__, "Unable to parse module directory. " + std::string(e.what()));
 		return std::string();
 	}
 }

--- a/srcStatic/ConsoleArgumentParser.h
+++ b/srcStatic/ConsoleArgumentParser.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include <string>
+
+// Returns an empty string if no console switch is found or if the switch is ill-formed.
+// Logs error and posts modal dialog if switch is ill-formed.
+std::string ParseCommandLine();

--- a/srcStatic/ConsoleArgumentParser.h
+++ b/srcStatic/ConsoleArgumentParser.h
@@ -4,4 +4,4 @@
 
 // Returns an empty string if no console switch is found or if the switch is ill-formed.
 // Logs error and posts modal dialog if switch is ill-formed.
-std::string ParseCommandLine();
+std::string FindModuleDirectory();

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <stdexcept>
 #include <cstddef>
+#include <system_error>
 
 std::string moduleDirectory;
 std::string moduleName;
@@ -87,14 +88,13 @@ void ConsoleModuleLoader::LoadModule()
 		return;
 	}
 
-	// Check if directory exists.
-	if (GetFileAttributesA(moduleDirectory.c_str()) == INVALID_FILE_ATTRIBUTES) {
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Module directory does not exist");
+	std::error_code errorCode;
+	if (!fs::is_directory(moduleDirectory, errorCode)) {
+		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to access the provided module directory. " + errorCode.message());
 		return;
 	}
 
 	SetArtPath();
-
 	LoadModuleDll();
 }
 

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -112,9 +112,13 @@ void ConsoleModuleLoader::SetArtPath()
 
 	// Insert hooks to make OP2 look for files in the module's directory
 	// In ResManager::GetFilePath
-	Op2MemSetDword((void*)0x004715C5, (DWORD)&GetArtPath - (GetLoadOffset() + (DWORD)0x004715C5 + sizeof(void*)));
-	// In ResManager::CreateStream
-	Op2MemSetDword((void*)0x00471B87, (DWORD)&GetArtPath - (GetLoadOffset() + (DWORD)0x00471B87 + sizeof(void*)));
+	bool success = Op2MemSetDword((void*)0x004715C5, (DWORD)(&GetArtPath) - (GetLoadOffset() + (DWORD)0x004715C5 + sizeof(void*)));
+	
+	// Only modify memory at second location if first modification succeeds.
+	if (success) {
+		// In ResManager::CreateStream
+		Op2MemSetDword((void*)0x00471B87, (DWORD)&GetArtPath - (GetLoadOffset() + (DWORD)0x00471B87 + sizeof(void*)));
+	}
 }
 
 void ConsoleModuleLoader::UnloadModule()

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -15,6 +15,9 @@ std::string moduleDirectory;
 
 ConsoleModuleLoader::ConsoleModuleLoader(const std::string& moduleRelativeDirectory)
 {
+	// Hack that clears variable not included in class
+	moduleDirectory = "";
+
 	if (moduleRelativeDirectory.empty()) {
 		return; // No Console Module Loaded
 	}

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -25,7 +25,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::string& moduleRelativeDirect
 
 	std::error_code errorCode;
 	if (!fs::is_directory(moduleDirectory, errorCode)) {
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to access the provided module directory. " + errorCode.message());
+		PostErrorMessage(__FILE__, __LINE__, "Unable to access the provided module directory. " + errorCode.message());
 		moduleDirectory = "";
 		moduleName = "";
 	}
@@ -69,7 +69,7 @@ void ConsoleModuleLoader::LoadModule()
 
 	std::error_code errorCode;
 	if (!fs::is_directory(moduleDirectory, errorCode)) {
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to access the provided module directory. " + errorCode.message());
+		PostErrorMessage(__FILE__, __LINE__, "Unable to access the provided module directory. " + errorCode.message());
 		return;
 	}
 
@@ -98,7 +98,7 @@ void ConsoleModuleLoader::LoadModuleDll()
 		const std::string errorMessage("Unable to load console module's dll from " + dllName +
 			". " + GetLastErrorStdString(TEXT("LoadLibrary")));
 
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, errorMessage);
+		PostErrorMessage(__FILE__, __LINE__, errorMessage);
 	}
 }
 

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -55,7 +55,7 @@ bool ConsoleModuleLoader::IsModuleLoaded(std::string moduleName)
 	return ToLowerInPlace(moduleName) == GetModuleName();
 }
 
-int __fastcall GetArtPath(void*, int, char*, char*, char *destBuffer, int bufferSize, char *defaultValue)
+int __fastcall GetArtPath(void*, int, char*, char*, char* destBuffer, int bufferSize, char* defaultValue)
 {
 	strcpy_s(destBuffer, bufferSize, moduleDirectory.c_str());
 	return moduleDirectory.size();

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -60,8 +60,7 @@ int __fastcall GetArtPath(void*, int, char*, char*, char *destBuffer, int buffer
 // Returns an empty string if no module is found or if the module request is ill-formed.
 std::string ConsoleModuleLoader::FindModuleDirectory()
 {
-	std::vector<std::string> arguments;
-	ParseCommandLine(arguments);
+	auto arguments = GetCommandLineArguments();
 
 	if (arguments.size() == 0) {
 		return std::string();
@@ -123,12 +122,12 @@ void ConsoleModuleLoader::LoadModuleDll()
 	}
 }
 
-void ConsoleModuleLoader::ParseCommandLine(std::vector<std::string>& arguments)
+std::vector<std::string> ConsoleModuleLoader::GetCommandLineArguments()
 {
-	arguments.clear();
+	std::vector<std::string> arguments;
 	int argumentCount;
-
-	LPWSTR *commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
+	LPWSTR* commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
+	
 	if (commandLineArgs == nullptr) {
 		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
 	}
@@ -152,6 +151,7 @@ void ConsoleModuleLoader::ParseCommandLine(std::vector<std::string>& arguments)
 	}
 
 	LocalFree(commandLineArgs);
+	return arguments;
 }
 
 bool ConsoleModuleLoader::ParseArgumentName(std::string& argument)

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -112,9 +112,9 @@ void ConsoleModuleLoader::SetArtPath()
 
 	// Insert hooks to make OP2 look for files in the module's directory
 	// In ResManager::GetFilePath
-	Op2MemSetDword((void*)0x004715C5, (DWORD)&GetArtPath - (loadOffset + (DWORD)0x004715C5 + sizeof(void*)));
+	Op2MemSetDword((void*)0x004715C5, (DWORD)&GetArtPath - (GetLoadOffset() + (DWORD)0x004715C5 + sizeof(void*)));
 	// In ResManager::CreateStream
-	Op2MemSetDword((void*)0x00471B87, (DWORD)&GetArtPath - (loadOffset + (DWORD)0x00471B87 + sizeof(void*)));
+	Op2MemSetDword((void*)0x00471B87, (DWORD)&GetArtPath - (GetLoadOffset() + (DWORD)0x00471B87 + sizeof(void*)));
 }
 
 void ConsoleModuleLoader::UnloadModule()

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -135,7 +135,7 @@ void ConsoleModuleLoader::ParseCommandLine(std::vector<std::string>& arguments)
 	else {
 		try {
 			// Ignore the first argument, which is the path of the executable.
-			for (int i = 1; i < argumentCount; i++) {
+			for (int i = 1; i < argumentCount; ++i) {
 				std::string argument;
 				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
 					PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to cast the " + std::to_string(i) +
@@ -202,7 +202,7 @@ std::string ConsoleModuleLoader::FormModRelativeDirectory(std::vector<std::strin
 {
 	std::string modRelativeDirectory;
 
-	for (std::size_t i = 0; i < arguments.size(); i++) {
+	for (std::size_t i = 0; i < arguments.size(); ++i) {
 		modRelativeDirectory += arguments[i];
 
 		if (i < arguments.size() - 1) {

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -146,7 +146,7 @@ void ConsoleModuleLoader::ParseCommandLine(std::vector<std::string>& arguments)
 			}
 		}
 		// Catch STL produced exceptions
-		catch (std::exception& e) {
+		catch (const std::exception& e) {
 			PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Error occurred attempting to parse command line arguments. Further parshing of command line arguments aborted. Internal Error: " + std::string(e.what()));
 		}
 	}
@@ -191,9 +191,9 @@ std::string ConsoleModuleLoader::ParseLoadModCommand(std::vector<std::string> ar
 
 		return modDirectory;
 	}
-	catch (std::exception e)
+	catch (const std::exception& e)
 	{
-		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to parse module directory");
+		PostErrorMessage("ConsoleModuleLoader.cpp", __LINE__, "Unable to parse module directory." + std::string(e.what()));
 		return std::string();
 	}
 }

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -5,9 +5,7 @@
 
 class ConsoleModuleLoader {
 public:
-	ConsoleModuleLoader();
-	// Test Constructor
-	ConsoleModuleLoader(const std::string& testModuleDirectory);
+	ConsoleModuleLoader(const std::string& moduleRelativeDirectory);
 	void LoadModule();
 	void UnloadModule();
 	void RunModule();
@@ -20,12 +18,6 @@ public:
 private:
 	HINSTANCE modDllHandle = nullptr;
 
-	std::string ParseCommandLine();
 	void LoadModuleDll();
-	std::vector<std::string> GetCommandLineArguments();
-	std::string GetSwitch(std::vector<std::string>& arguments);
-	std::string ParseSwitchName(std::string switchName);
-	std::string ParseLoadModCommand(std::vector<std::string> arguments);
-	std::string FormModRelativeDirectory(std::vector<std::string> arguments);
 	void SetArtPath();
 };

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -20,10 +20,11 @@ public:
 private:
 	HINSTANCE modDllHandle = nullptr;
 
-	std::string FindModuleDirectory();
+	std::string ParseCommandLine();
 	void LoadModuleDll();
 	std::vector<std::string> GetCommandLineArguments();
-	bool ParseArgumentName(std::string& argument);
+	std::string GetSwitch(std::vector<std::string>& arguments);
+	std::string ParseSwitchName(std::string switchName);
 	std::string ParseLoadModCommand(std::vector<std::string> arguments);
 	std::string FormModRelativeDirectory(std::vector<std::string> arguments);
 	void SetArtPath();

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -22,7 +22,7 @@ private:
 
 	std::string FindModuleDirectory();
 	void LoadModuleDll();
-	void ParseCommandLine(std::vector<std::string>& arguments);
+	std::vector<std::string> GetCommandLineArguments();
 	bool ParseArgumentName(std::string& argument);
 	std::string ParseLoadModCommand(std::vector<std::string> arguments);
 	std::string FormModRelativeDirectory(std::vector<std::string> arguments);

--- a/srcStatic/GlobalDefines.cpp
+++ b/srcStatic/GlobalDefines.cpp
@@ -6,6 +6,8 @@
 #include <sstream>
 #include <cstddef>
 
+bool modalDialogsDisabled = false;
+
 void OutputDebug(std::string message)
 {
 #ifdef DEBUG
@@ -13,11 +15,18 @@ void OutputDebug(std::string message)
 #endif
 }
 
+void DisableModalDialogs()
+{
+	modalDialogsDisabled = true;
+}
+
 void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, std::string errorMessage)
 {
 	const std::string formattedMessage = sourceFilename + ", Line: " + std::to_string(lineInSourceCode) + ": " + errorMessage;
 	logger.Log(formattedMessage);
-	MessageBoxA(nullptr, formattedMessage.c_str(), "Outpost 2 Error", MB_ICONERROR);
+	if (!modalDialogsDisabled) {
+		MessageBoxA(nullptr, formattedMessage.c_str(), "Outpost 2 Error", MB_ICONERROR);
+	}
 }
 
 std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption)

--- a/srcStatic/GlobalDefines.cpp
+++ b/srcStatic/GlobalDefines.cpp
@@ -1,5 +1,5 @@
 #include "GlobalDefines.h"
-
+#include "FileSystemHelper.h"
 #include "op2ext-Internal.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -20,8 +20,11 @@ void DisableModalDialogs()
 	modalDialogsDisabled = true;
 }
 
-void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, std::string errorMessage)
+void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, const std::string& errorMessage)
 {
+	// __FILE__ returns absolute filename. Strip the absolute path to reduce clutter in logger.
+	sourceFilename = fs::path(sourceFilename).filename().string();
+
 	const std::string formattedMessage = sourceFilename + ", Line: " + std::to_string(lineInSourceCode) + ": " + errorMessage;
 	logger.Log(formattedMessage);
 	if (!modalDialogsDisabled) {

--- a/srcStatic/GlobalDefines.h
+++ b/srcStatic/GlobalDefines.h
@@ -15,6 +15,8 @@ enum class TrimOption
 	None
 };
 
+// DisableModalDialogs will stop PostErrorMessage from posting modal dialogs. For use in test environment.
+void DisableModalDialogs();
 // Logs an error message with the logger and then posts it to user in a modal dialog box.
 void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, std::string errorMessage);
 std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption);

--- a/srcStatic/GlobalDefines.h
+++ b/srcStatic/GlobalDefines.h
@@ -18,6 +18,6 @@ enum class TrimOption
 // DisableModalDialogs will stop PostErrorMessage from posting modal dialogs. For use in test environment.
 void DisableModalDialogs();
 // Logs an error message with the logger and then posts it to user in a modal dialog box.
-void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, std::string errorMessage);
+void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, const std::string& errorMessage);
 std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption);
 std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace = " \t");

--- a/srcStatic/IniModuleLoader.cpp
+++ b/srcStatic/IniModuleLoader.cpp
@@ -25,7 +25,7 @@ void IniModuleLoader::LoadModule(std::string sectionName)
 		moduleEntry.handle = LoadModuleDll(sectionName);
 	}
 	catch (const std::exception& error) {
-		PostErrorMessage("IniModuleLoader.cpp", __LINE__, error.what());
+		PostErrorMessage(__FILE__, __LINE__, error.what());
 		return;
 	}
 

--- a/srcStatic/Logger.cpp
+++ b/srcStatic/Logger.cpp
@@ -15,7 +15,7 @@ Logger::Logger() :
 	logFile(GetGameDirectory() + "\\Outpost2Log.txt", std::ios::app | std::ios::out | std::ios::binary)
 {
 	if (!logFile.is_open()) {
-		PostErrorMessage("Logger.cpp", __LINE__, "Unable to create or open Outpost2Log.txt");
+		PostErrorMessage(__FILE__, __LINE__, "Unable to create or open Outpost2Log.txt");
 	}
 }
 

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -1,5 +1,4 @@
 #include "OP2Memory.h"
-
 #include "GlobalDefines.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -21,24 +20,20 @@ void SetLoadOffset()
 
 bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size)
 {
-	DWORD oldAttr;
-	DWORD ignoredAttr;
-	BOOL bSuccess;
 	void* destAddr = (void*)(loadOffset + (int)destBaseAddr);
 
-	// Try to unprotect the memory
-	bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
+	// Try to unprotect memory
+	DWORD oldAttr;
+	BOOL bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
 	if (!bSuccess) {
-		char buffer[64];
-		_snprintf_s(buffer, sizeof(buffer), "Op2MemCopy: Error unprotecting memory at: %x", reinterpret_cast<unsigned int>(destAddr));
-		PostErrorMessage(__FILE__, __LINE__, buffer);
-		return false;	// Abort if failed
+		PostErrorMessage(__FILE__, __LINE__, "Error unprotecting memory at: " + std::to_string(reinterpret_cast<unsigned int>(destAddr)));
+		return false;
 	}
 
-	// Do the memory copy
 	memcpy(destAddr, sourceAddr, size);
 
-	// Reprotect the memory with the original attributes
+	// Reprotect memory with the original attributes
+	DWORD ignoredAttr;
 	bSuccess = VirtualProtect(destAddr, size, oldAttr, &ignoredAttr);
 
 	return (bSuccess != 0);
@@ -57,24 +52,20 @@ bool Op2MemSetDword(void* destBaseAddr, void* dword)
 
 bool Op2MemSet(void* destBaseAddr, unsigned char value, int size)
 {
-	DWORD oldAttr;
-	DWORD ignoredAttr;
-	BOOL bSuccess;
 	void* destAddr = (void*)(loadOffset + (int)destBaseAddr);
 
-	// Try to unprotect the memory
-	bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
+	// Try to unprotect memory
+	DWORD oldAttr;
+	BOOL bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
 	if (!bSuccess) {
-		char buffer[64];
-		_snprintf_s(buffer, sizeof(buffer), "Op2MemSet: Error unprotecting memory at: %x", reinterpret_cast<unsigned int>(destAddr));
-		PostErrorMessage(__FILE__, __LINE__, buffer);
-		return false;	// Abort if failed
+		PostErrorMessage(__FILE__, __LINE__, "Error unprotecting memory at: " + std::to_string(reinterpret_cast<unsigned int>(destAddr)));
+		return false;
 	}
 
-	// Do the memory copy
 	memset(destAddr, value, size);
 
-	// Reprotect the memory with the original attributes
+	// Reprotect memory with the original attributes
+	DWORD ignoredAttr;
 	bSuccess = VirtualProtect(destAddr, size, oldAttr, &ignoredAttr);
 
 	return (bSuccess != 0);

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -2,6 +2,7 @@
 #include "GlobalDefines.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <sstream>
 
 bool memoryCommandsDisabled;
 int loadOffset = 0;
@@ -44,7 +45,9 @@ bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size)
 	DWORD oldAttr;
 	BOOL bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
 	if (!bSuccess) {
-		PostErrorMessage(__FILE__, __LINE__, "Error unprotecting memory at: " + std::to_string(reinterpret_cast<unsigned int>(destAddr)));
+		std::ostringstream stringStream;
+		stringStream << "Error unprotecting memory at: 0x" << std::hex << reinterpret_cast<unsigned int>(destAddr) << ".";
+		PostErrorMessage(__FILE__, __LINE__, stringStream.str());
 		return false;
 	}
 
@@ -80,7 +83,9 @@ bool Op2MemSet(void* destBaseAddr, unsigned char value, int size)
 	DWORD oldAttr;
 	BOOL bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
 	if (!bSuccess) {
-		PostErrorMessage(__FILE__, __LINE__, "Error unprotecting memory at: " + std::to_string(reinterpret_cast<unsigned int>(destAddr)));
+		std::ostringstream stringStream;
+		stringStream << "Error unprotecting memory at: 0x" << std::hex << reinterpret_cast<unsigned int>(destAddr) << ".";
+		PostErrorMessage(__FILE__, __LINE__, stringStream.str());
 		return false;
 	}
 

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -13,7 +13,7 @@ void SetLoadOffset()
 	void* op2ModuleBase = GetModuleHandle("Outpost2.exe");
 
 	if (op2ModuleBase == 0) {
-		PostErrorMessage("OP2Memory.cpp", __LINE__, "Could not find Outpost2.exe module base address.");
+		PostErrorMessage(__FILE__, __LINE__, "Could not find Outpost2.exe module base address.");
 	}
 
 	loadOffset = (int)op2ModuleBase - ExpectedOutpost2Addr;
@@ -31,7 +31,7 @@ bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size)
 	if (!bSuccess) {
 		char buffer[64];
 		_snprintf_s(buffer, sizeof(buffer), "Op2MemCopy: Error unprotecting memory at: %x", reinterpret_cast<unsigned int>(destAddr));
-		PostErrorMessage("op2ext.cpp", __LINE__, buffer);
+		PostErrorMessage(__FILE__, __LINE__, buffer);
 		return false;	// Abort if failed
 	}
 
@@ -67,7 +67,7 @@ bool Op2MemSet(void* destBaseAddr, unsigned char value, int size)
 	if (!bSuccess) {
 		char buffer[64];
 		_snprintf_s(buffer, sizeof(buffer), "Op2MemSet: Error unprotecting memory at: %x", reinterpret_cast<unsigned int>(destAddr));
-		PostErrorMessage("op2ext.cpp", __LINE__, buffer);
+		PostErrorMessage(__FILE__, __LINE__, buffer);
 		return false;	// Abort if failed
 	}
 

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -3,12 +3,22 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+bool memoryCommandsDisabled;
 int loadOffset = 0;
 const int ExpectedOutpost2Addr = 0x00400000;
+
+void DisableMemoryCommands()
+{
+	memoryCommandsDisabled = true;
+}
 
 // Adjust offsets in case Outpost2.exe module is relocated
 void SetLoadOffset()
 {
+	if (memoryCommandsDisabled) {
+		return;
+	}
+
 	void* op2ModuleBase = GetModuleHandle("Outpost2.exe");
 
 	if (op2ModuleBase == 0) {
@@ -24,6 +34,10 @@ int GetLoadOffset() {
 
 bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size)
 {
+	if (memoryCommandsDisabled) {
+		return false;
+	}
+
 	void* destAddr = (void*)(loadOffset + (int)destBaseAddr);
 
 	// Try to unprotect memory
@@ -56,6 +70,10 @@ bool Op2MemSetDword(void* destBaseAddr, void* dword)
 
 bool Op2MemSet(void* destBaseAddr, unsigned char value, int size)
 {
+	if (memoryCommandsDisabled) {
+		return false;
+	}
+
 	void* destAddr = (void*)(loadOffset + (int)destBaseAddr);
 
 	// Try to unprotect memory

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -18,6 +18,10 @@ void SetLoadOffset()
 	loadOffset = (int)op2ModuleBase - ExpectedOutpost2Addr;
 }
 
+int GetLoadOffset() {
+	return loadOffset;
+}
+
 bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size)
 {
 	void* destAddr = (void*)(loadOffset + (int)destBaseAddr);

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -2,9 +2,8 @@
 
 #pragma once
 
-extern int loadOffset;
-
 void SetLoadOffset();
+int GetLoadOffset();
 
 bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size);
 bool Op2MemSet(void* destBaseAddr, unsigned char value, int size);

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+// Disable memory commands when operating in test environment and Outpost2.exe is not available
+void DisableMemoryCommands();
+
 void SetLoadOffset();
 int GetLoadOffset();
 

--- a/srcStatic/op2ext-Internal.cpp
+++ b/srcStatic/op2ext-Internal.cpp
@@ -1,8 +1,10 @@
 #include "op2ext-Internal.h"
+#include "FileSystemHelper.h"
+#include "ConsoleArgumentParser.h"
 
 bool modulesRunning = false;
 
 Logger logger;
 VolList volList;
-ConsoleModuleLoader consoleModLoader;
+ConsoleModuleLoader consoleModLoader(ParseCommandLine());
 IniModuleLoader iniModuleLoader;

--- a/srcStatic/op2ext-Internal.cpp
+++ b/srcStatic/op2ext-Internal.cpp
@@ -1,8 +1,17 @@
 #include "op2ext-Internal.h"
 #include "FileSystemHelper.h"
 #include "ConsoleArgumentParser.h"
+#include "OP2Memory.h"
+#include "GlobalDefines.h"
+
 
 bool modulesRunning = false;
+
+void EnableTestEnvironment()
+{
+	DisableModalDialogs();
+	DisableMemoryCommands();
+}
 
 Logger logger;
 VolList volList;

--- a/srcStatic/op2ext-Internal.cpp
+++ b/srcStatic/op2ext-Internal.cpp
@@ -15,5 +15,5 @@ void EnableTestEnvironment()
 
 Logger logger;
 VolList volList;
-ConsoleModuleLoader consoleModLoader(ParseCommandLine());
+ConsoleModuleLoader consoleModLoader(FindModuleDirectory());
 IniModuleLoader iniModuleLoader;

--- a/srcStatic/op2ext-Internal.h
+++ b/srcStatic/op2ext-Internal.h
@@ -12,6 +12,9 @@
 // Attempting further initialization commands will cause errors.
 extern bool modulesRunning;
 
+// Set op2ext to operate in a test environment where Outpost2.exe is unavailable
+void EnableTestEnvironment();
+
 extern Logger logger;
 extern VolList volList;
 extern ConsoleModuleLoader consoleModLoader;

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -123,6 +123,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="ConsoleArgumentParser.cpp" />
     <ClCompile Include="FileSystemHelper.cpp" />
     <ClCompile Include="GlobalDefines.cpp" />
     <ClCompile Include="IniModuleLoader.cpp" />
@@ -137,6 +138,7 @@
     <ClCompile Include="WindowsModule.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ConsoleArgumentParser.h" />
     <ClInclude Include="FileSystemHelper.h" />
     <ClInclude Include="GlobalDefines.h" />
     <ClInclude Include="IniModuleLoader.h" />

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -51,6 +51,9 @@
     <ClCompile Include="StringConversion.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ConsoleArgumentParser.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IpDropDown.h">
@@ -87,6 +90,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="StringConversion.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ConsoleArgumentParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -5,7 +5,7 @@
 
 TEST(ConsoleModuleLoader, NoModuleLoaded)
 {
-	ConsoleModuleLoader consoleModLoader;
+	ConsoleModuleLoader consoleModLoader("");
 
 	// Returns empty string if no module available
 	EXPECT_EQ("", consoleModLoader.GetModuleName());

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -40,7 +40,6 @@ TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 
 	EXPECT_EQ(1u, consoleModLoader.Count());
 
-	// No DLL to load, but will attempt to set memory addresses
 	EXPECT_NO_THROW(consoleModLoader.LoadModule());
 	EXPECT_NO_THROW(consoleModLoader.RunModule());
 	EXPECT_NO_THROW(consoleModLoader.UnloadModule());

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -1,4 +1,6 @@
 #include "ConsoleModuleLoader.h"
+#include "FileSystemHelper.h"
+#include "StringConversion.h"
 #include <gtest/gtest.h>
 #include <string>
 
@@ -9,44 +11,60 @@ TEST(ConsoleModuleLoader, NoModuleLoaded)
 
 	// Returns empty string if no module available
 	EXPECT_EQ("", consoleModLoader.GetModuleName());
+	EXPECT_EQ("", consoleModLoader.GetModuleDirectory());
 
 	EXPECT_EQ(0u, consoleModLoader.Count());
+
 	// Module name cannot be an empty string
 	EXPECT_FALSE(consoleModLoader.IsModuleLoaded(""));
 	EXPECT_FALSE(consoleModLoader.IsModuleLoaded("TEST"));
+
+	// No module present to load, functions should return without doing anything
+	EXPECT_NO_THROW(consoleModLoader.LoadModule());
+	EXPECT_NO_THROW(consoleModLoader.RunModule());
+	EXPECT_NO_THROW(consoleModLoader.UnloadModule());
 }
 
-TEST(ConsoleModuleLoader, GetModuleDirectory)
+TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 {
-	const std::string testModule("TestModule");
-	ConsoleModuleLoader consoleModLoader(testModule);
+	const auto moduleName("NoDllTest");
+	ConsoleModuleLoader consoleModLoader(moduleName);
 
-	EXPECT_NE("", consoleModLoader.GetModuleDirectory());
-	EXPECT_EQ(testModule, consoleModLoader.GetModuleDirectory());
+	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
+	EXPECT_EQ(moduleDirectory, consoleModLoader.GetModuleDirectory());
+	EXPECT_EQ(ToLower(moduleName), consoleModLoader.GetModuleName());
+
+	EXPECT_TRUE(consoleModLoader.IsModuleLoaded(moduleName));
+	EXPECT_FALSE(consoleModLoader.IsModuleLoaded(""));
+	EXPECT_FALSE(consoleModLoader.IsModuleLoaded("UnknownModule"));
+
+	EXPECT_EQ(1u, consoleModLoader.Count());
+
+	// No DLL to load, but will attempt to set memory addresses
+	EXPECT_NO_THROW(consoleModLoader.LoadModule());
+	EXPECT_NO_THROW(consoleModLoader.RunModule());
+	EXPECT_NO_THROW(consoleModLoader.UnloadModule());
 }
 
-TEST(ConsoleModuleLoader, GetModuleName)
+TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 {
-	const std::string testModule("testmodule");
-	ConsoleModuleLoader consoleModLoader(testModule);
+	const std::string moduleName("InvalidDllTest");
+	ConsoleModuleLoader consoleModLoader(moduleName);
 
-	EXPECT_NE("", consoleModLoader.GetModuleName());
-	EXPECT_EQ(testModule, consoleModLoader.GetModuleName());
-}
+	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
+	EXPECT_EQ(moduleDirectory, consoleModLoader.GetModuleDirectory());
+	EXPECT_EQ(ToLower(moduleName), consoleModLoader.GetModuleName());
 
-TEST(ConsoleModuleLoader, IsModuleLoaded)
-{
-	const std::string testModule("TestModule");
-	ConsoleModuleLoader consoleModuleLoader(testModule);
+	EXPECT_TRUE(consoleModLoader.IsModuleLoaded(moduleName));
+	EXPECT_FALSE(consoleModLoader.IsModuleLoaded(""));
+	EXPECT_FALSE(consoleModLoader.IsModuleLoaded("UnknownModule"));
 
-	EXPECT_TRUE(consoleModuleLoader.IsModuleLoaded(testModule));
+	EXPECT_EQ(1u, consoleModLoader.Count());
 
-	EXPECT_FALSE(consoleModuleLoader.IsModuleLoaded(""));
-	EXPECT_FALSE(consoleModuleLoader.IsModuleLoaded("UnknownModule"));
-}
+	// DLL file is empty and should be aborted
+	EXPECT_NO_THROW(consoleModLoader.LoadModule());
 
-TEST(ConsoleModuleLoader, Count)
-{
-	ConsoleModuleLoader consoleModuleLoader("TestModule");
-	EXPECT_EQ(1u, consoleModuleLoader.Count());
+	// Functions should return without doing anything since module load is aborted
+	EXPECT_NO_THROW(consoleModLoader.RunModule());
+	EXPECT_NO_THROW(consoleModLoader.UnloadModule());
 }

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -1,5 +1,5 @@
 #include "FileSystemHelper.h"
-#include "GlobalDefines.h"
+#include "op2ext-Internal.h"
 #include <gtest/gtest.h>
 #include <fstream>
 
@@ -11,7 +11,7 @@ int main(int argc, char** argv)
 {
 	::testing::InitGoogleTest(&argc, argv);
 
-	DisableModalDialogs();
+	EnableTestEnvironment();
 	SetupConsoleModTestEnvironment();
 
 	return RUN_ALL_TESTS();

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -1,0 +1,32 @@
+#include "FileSystemHelper.h"
+#include "GlobalDefines.h"
+#include <gtest/gtest.h>
+#include <fstream>
+
+
+void SetupConsoleModTestEnvironment();
+
+
+int main(int argc, char** argv) 
+{
+	::testing::InitGoogleTest(&argc, argv);
+
+	DisableModalDialogs();
+	SetupConsoleModTestEnvironment();
+
+	return RUN_ALL_TESTS();
+}
+
+
+void SetupConsoleModTestEnvironment()
+{
+	fs::path gameDirectory(GetGameDirectory());
+
+	fs::create_directory(gameDirectory / "NoDllTest");
+
+	fs::path emptyModuleTestDirectory = gameDirectory / "InvalidDllTest";
+
+	fs::create_directory(emptyModuleTestDirectory);
+	std::ofstream stream(emptyModuleTestDirectory / "op2mod.dll");
+	stream.close();
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <ClCompile Include="ConsolueModuleLoader.test.cpp" />
     <ClCompile Include="IniModuleLoader.test.cpp" />
+    <ClCompile Include="Main.cpp" />
     <ClCompile Include="op2ext.test.cpp" />
     <ClCompile Include="StringConversion.test.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Closes #96 
Closes #72 

Some of the commits are a bit chunky due to the large refactoring and perhaps my less than stellar commit skills.

Tests are still not super useful. You don't really know if the guts of the ConsoleModuleLoader are properly running, only that they do not through exceptions / crash. Some of the functionality like getting the module's name or directory I think are fairly well tested now though.