### PR TITLE
Add basic logger tests

### DIFF
--- a/test/Logger.test.cpp
+++ b/test/Logger.test.cpp
@@ -4,7 +4,6 @@
 #include <system_error>
 
 const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
-Logger logger;
 
 TEST(Logger, LogFileExists)
 {
@@ -14,6 +13,8 @@ TEST(Logger, LogFileExists)
 
 TEST(Logger, MessageLogged)
 {
+	Logger logger;
+
 	const uintmax_t preFileSize = fs::file_size(logPath);
 	EXPECT_NO_THROW(logger.Log("Test Log Message"));
 

--- a/test/Logger.test.cpp
+++ b/test/Logger.test.cpp
@@ -1,0 +1,21 @@
+#include "Logger.h"
+#include "FileSystemHelper.h"
+#include <gtest/gtest.h>
+#include <system_error>
+
+const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
+Logger logger;
+
+TEST(Logger, LogFileExists)
+{
+	std::error_code errorCode;
+	ASSERT_TRUE(fs::exists(logPath, errorCode));
+}
+
+TEST(Logger, MessageLogged)
+{
+	const uintmax_t preFileSize = fs::file_size(logPath);
+	EXPECT_NO_THROW(logger.Log("Test Log Message"));
+
+	ASSERT_GT(fs::file_size(logPath), preFileSize);
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -27,6 +27,7 @@
   <ItemGroup>
     <ClCompile Include="ConsolueModuleLoader.test.cpp" />
     <ClCompile Include="IniModuleLoader.test.cpp" />
+    <ClCompile Include="Logger.test.cpp" />
     <ClCompile Include="op2ext.test.cpp" />
     <ClCompile Include="StringConversion.test.cpp" />
   </ItemGroup>


### PR DESCRIPTION
Very rudimentary start to testing the logger.

I want to explore adding a log test that can be run by other unit tests. For example, you should be able to test that certain failures in the ConsoleModuleLoader actually log a message.

I thought the easiest start would be just checking to make sure the logger file increased in size. This was sort of a test to make sure that check would work. More sophisticated tests could be added that make sure the right message is written in the future. None of this is added in this PR.