### PR TITLE
Allow double spaces in console argument

### DIFF
--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -3,7 +3,6 @@
 #include "FileSystemHelper.h"
 #include "GlobalDefines.h"
 #include <windows.h> // Cannot use WIN32_LEAN_AND_MEAN (it does not contain CommandLineToArgvW)
-#include <system_error>
 #include <vector>
 
 
@@ -11,7 +10,6 @@ std::vector<std::string> GetCommandLineArguments();
 std::string GetSwitch(std::vector<std::string>& arguments);
 std::string ParseSwitchName(std::string switchName);
 std::string ParseLoadModCommand(std::vector<std::string> arguments);
-std::string FormModRelativeDirectory(std::vector<std::string> arguments);
 
 
 std::string FindModuleDirectory()
@@ -98,26 +96,10 @@ std::string ParseLoadModCommand(std::vector<std::string> arguments)
 		return std::string();
 	}
 
-	try {
-		return FormModRelativeDirectory(arguments);
-	}
-	catch (const std::exception& e) {
-		PostErrorMessage(__FILE__, __LINE__, "Unable to parse module directory. " + std::string(e.what()));
+	if (arguments.size() > 1) {
+		PostErrorMessage(__FILE__, __LINE__, "Too many arguments passed into switch LoadMod. If module relative directory contains spaces, surround the directory in quotes");
 		return std::string();
 	}
-}
 
-std::string FormModRelativeDirectory(std::vector<std::string> arguments)
-{
-	std::string modRelativeDirectory;
-
-	for (std::size_t i = 0; i < arguments.size(); ++i) {
-		modRelativeDirectory += arguments[i];
-
-		if (i < arguments.size() - 1) {
-			modRelativeDirectory += " ";
-		}
-	}
-
-	return modRelativeDirectory;
+	return arguments[0];
 }

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -3,7 +3,6 @@
 #include "FileSystemHelper.h"
 #include "GlobalDefines.h"
 #include <windows.h> // Cannot use WIN32_LEAN_AND_MEAN (it does not contain CommandLineToArgvW)
-#include <vector>
 
 
 std::vector<std::string> GetCommandLineArguments();
@@ -14,8 +13,12 @@ std::string ParseLoadModCommand(std::vector<std::string> arguments);
 
 std::string FindModuleDirectory()
 {
-	auto arguments = GetCommandLineArguments();
+	const auto arguments = GetCommandLineArguments();
+	return FindModuleDirectory(arguments);
+}
 
+std::string FindModuleDirectory(std::vector<std::string> arguments)
+{
 	const std::string switchName = GetSwitch(arguments);
 
 	if (switchName.empty()) {

--- a/srcStatic/ConsoleArgumentParser.h
+++ b/srcStatic/ConsoleArgumentParser.h
@@ -1,7 +1,13 @@
 #pragma once
 
+#include <vector>
 #include <string>
 
 // Returns an empty string if no console switch is found or if the switch is ill-formed.
 // Logs error and posts modal dialog if switch is ill-formed.
+// Automatically pulls Console arguments using CommandLineToArgvW
 std::string FindModuleDirectory();
+
+// Instead of pulling Console arguments, allows passing in arguments for testability
+// Passed in values should already be formatted as the return value of CommandLineToArgvW without the executable's name
+std::string FindModuleDirectory(std::vector<std::string> arguments);

--- a/test/ConsoleArgumentParser.test.cpp
+++ b/test/ConsoleArgumentParser.test.cpp
@@ -1,0 +1,36 @@
+#include <ConsoleArgumentParser.h>
+#include <gtest/gtest.h>
+#include <vector>
+#include <string>
+
+TEST(ConsoleArgumentParser, NoArgument) {
+	const std::vector<std::string> arguments;
+	EXPECT_EQ("", FindModuleDirectory(arguments));
+}
+
+TEST(ConsoleArgumentParser, WrongSwitchName) {
+	const std::vector<std::string> arguments{ "/WrongSwitch" };
+	EXPECT_EQ("", FindModuleDirectory(arguments));
+}
+
+TEST(ConsoleArgumentParser, NoSwitchArgument) {
+	const std::vector<std::string> arguments{ "/loadmod" };
+	EXPECT_EQ("", FindModuleDirectory(arguments));
+}
+
+TEST(ConsoleArgumentParser, TooManyArguments) {
+	const std::vector<std::string> arguments{ "/loadmod", "path1", "path2" };
+	EXPECT_EQ("", FindModuleDirectory(arguments));
+}
+
+TEST(ConsoleArgumentParser, WellFormedNoSpaces) {
+	const std::string path("path");
+	const std::vector<std::string> arguments{ "/loadmod", path };
+	EXPECT_EQ(path, FindModuleDirectory(arguments));
+}
+
+TEST(ConsoleArgmunetParser, WellFormedSpaces) {
+	const std::string path("paths with spaces");
+	const std::vector<std::string> arguments{ "/loadmod", path };
+	EXPECT_EQ(path, FindModuleDirectory(arguments));
+}

--- a/test/Logger.test.cpp
+++ b/test/Logger.test.cpp
@@ -2,6 +2,7 @@
 #include "FileSystemHelper.h"
 #include <gtest/gtest.h>
 #include <system_error>
+#include <cstdint>
 
 const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
 

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -25,6 +25,7 @@
   <ImportGroup Label="PropertySheets" />
   <PropertyGroup Label="UserMacros" />
   <ItemGroup>
+    <ClCompile Include="ConsoleArgumentParser.test.cpp" />
     <ClCompile Include="ConsolueModuleLoader.test.cpp" />
     <ClCompile Include="FileSystemHelper.test.cpp" />
     <ClCompile Include="IniModuleLoader.test.cpp" />


### PR DESCRIPTION
Updated ConsoleArgumentParser so unit tests could act on it without actually passing multiple command line arguments (if that is even possible?). 

Added test cases for ConsoleArgumentParser.

How testing if the ConsoleArgumentParser checks if messages were logged is messy. I couldn't come up with a better solution although I'm sure it exists.

More important, it Closes #98 