### PR TITLE
Disable running unit tests on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ jobs:
       - run: git submodule update --init || true
       - run: make --keep-going
       - run: make --keep-going test
-      - run: make --keep-going check
+#      - run: make --keep-going check


### PR DESCRIPTION
Currently the unit tests will randomly crash on CircleCI. Most runs will crash. Until we can figure out why and do something to prevent this, we should just disable the unit tests for now.

Edit: This is a temporary solution for Issue #95.