### PR TITLE
Update makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -97,8 +97,8 @@ gtest-clean:
 	rm -rf "$(GTESTBUILDDIR)"
 
 
-# Objects with references to Outpost2DLL or _ReturnAddress are a problem for the linker
-OBJSWITHREFS := $(OBJDIR)/DllMain.o $(OBJDIR)/IpDropDown.o
+# Objects with references to Outpost2DLL are a problem for the linker
+OBJSWITHREFS := $(OBJDIR)/DllMain.o
 SRCOBJS := $(filter-out $(OBJSWITHREFS),$(OBJS)) # Remove objects with problem references
 
 TESTDIR := test

--- a/makefile
+++ b/makefile
@@ -88,7 +88,7 @@ GTESTLIBDIR := /usr/i686-w64-mingw32/lib/
 .PHONY: gtest gtest-install gtest-clean
 gtest:
 	mkdir -p "$(GTESTBUILDDIR)"
-	cd "$(GTESTBUILDDIR)" && cmake -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON "$(GTESTSRCDIR)"
+	cd "$(GTESTBUILDDIR)" && cmake -DCMAKE_CXX_COMPILER="$(CXX)" -DCMAKE_C_COMPILER="$(CC)" -DCMAKE_CXX_FLAGS="-std=c++17" -DCMAKE_SYSTEM_NAME="Windows" -Dgtest_disable_pthreads=ON "$(GTESTSRCDIR)"
 	make -C "$(GTESTBUILDDIR)"
 gtest-install:
 	cp $(GTESTBUILDDIR)googlemock/gtest/lib*.a "$(GTESTLIBDIR)"

--- a/makefile
+++ b/makefile
@@ -107,8 +107,8 @@ TESTSRCS := $(shell find $(TESTDIR) -name '*.cpp')
 TESTOBJS := $(patsubst $(TESTDIR)/%.cpp,$(TESTOBJDIR)/%.o,$(TESTSRCS))
 TESTFOLDERS := $(sort $(dir $(TESTSRCS)))
 TESTCPPFLAGS := -I$(SRCDIR) -I$(GTESTINCDIR)
-TESTLDFLAGS := -static-libgcc -static-libstdc++ -L./ -L$(GTESTBUILDDIR)googlemock/ -L$(GTESTBUILDDIR)googlemock/gtest/
-TESTLIBS := -lgtest -lgtest_main -lstdc++fs
+TESTLDFLAGS := $(LDFLAGS) -L./ -L$(GTESTBUILDDIR)googlemock/ -L$(GTESTBUILDDIR)googlemock/gtest/
+TESTLIBS := $(LDLIBS) -lgtest -lgtest_main
 TESTOUTPUT := $(BUILDDIR)/testBin/runTests
 
 TESTDEPFLAGS = -MT $@ -MMD -MP -MF $(TESTOBJDIR)/$*.Td


### PR DESCRIPTION
Various Linux only updates:
- Google Test is compiled with the same compiler as the main project
- Main project linker settings are passed through to the test project linker settings
- Removed obsolete object file link exclusion for `IpDropDown.cpp`
