### PR TITLE
Fix global init order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,4 +9,4 @@ jobs:
       - run: git submodule update --init || true
       - run: make --keep-going
       - run: make --keep-going test
-#      - run: make --keep-going check
+      - run: make --keep-going check

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -11,7 +11,9 @@
 #include <cstddef>
 #include <system_error>
 
-std::string moduleDirectory;
+
+extern std::string moduleDirectory;
+
 
 ConsoleModuleLoader::ConsoleModuleLoader(const std::string& moduleRelativeDirectory)
 {

--- a/srcStatic/op2ext-Internal.cpp
+++ b/srcStatic/op2ext-Internal.cpp
@@ -6,14 +6,15 @@
 
 
 bool modulesRunning = false;
+Logger logger;
+VolList volList;
+std::string moduleDirectory; // Must be defined + initialized before consoleModLoader
+ConsoleModuleLoader consoleModLoader(FindModuleDirectory());
+IniModuleLoader iniModuleLoader;
+
 
 void EnableTestEnvironment()
 {
 	DisableModalDialogs();
 	DisableMemoryCommands();
 }
-
-Logger logger;
-VolList volList;
-ConsoleModuleLoader consoleModLoader(FindModuleDirectory());
-IniModuleLoader iniModuleLoader;


### PR DESCRIPTION
The `moduleDirectory` global must be declared and initialized before the `consoleModuleLoader` global that uses it. If the initialization is reversed, the `consoleModuleLoader` object will access an uninitialized global variable, which can lead to crashes.

This closes #95.
