### PR TITLE
Remove Visual Studio Source and Header Filters

### DIFF
--- a/TestModule/TestModule.vcxproj.filters
+++ b/TestModule/TestModule.vcxproj.filters
@@ -1,39 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
-      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
-      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
-      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
-    </Filter>
+    <ClCompile Include="DllMain.cpp"/>
+    <ClCompile Include="TestFunctions.cpp"/>
+    <ClCompile Include="CountFilesByTypeInDirectory.cpp"/>
+    <ClCompile Include="CompatibilityTest.c"/>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="DllMain.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="TestFunctions.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="CountFilesByTypeInDirectory.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="CompatibilityTest.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="TestFunctions.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="CountFilesByTypeInDirectory.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <ClInclude Include="TestFunctions.h"/>
+    <ClInclude Include="CountFilesByTypeInDirectory.h"/>
   </ItemGroup>
 </Project>

--- a/srcDLL/op2extDLL.vcxproj.filters
+++ b/srcDLL/op2extDLL.vcxproj.filters
@@ -1,38 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{e1e9d4be-ad81-444f-9363-c0ff5cbd0a45}</UniqueIdentifier>
-      <Extensions>cpp;c;cxx;rc;def;r;odl;idl;hpj;bat</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{7d5fe7b3-fe1a-4aac-bf30-149a7fc653da}</UniqueIdentifier>
-      <Extensions>h;hpp;hxx;hm;inl</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{dee9bab8-3306-4795-9a0a-1d0a43037c65}</UniqueIdentifier>
-      <Extensions>ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe</Extensions>
-    </Filter>
+    <ClCompile Include="op2ext.cpp"/>
+    <ClCompile Include="DllMain.cpp"/>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="op2ext.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="DllMain.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
+    <ClInclude Include="op2ext.h"/>
+    <ClInclude Include="resource.h"/>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="op2ext.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="resource.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="op2ext.rc">
-      <Filter>Source Files</Filter>
-    </ResourceCompile>
+    <ResourceCompile Include="op2ext.rc"/>
   </ItemGroup>
 </Project>

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -1,99 +1,33 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="Source Files">
-      <UniqueIdentifier>{e1e9d4be-ad81-444f-9363-c0ff5cbd0a45}</UniqueIdentifier>
-      <Extensions>cpp;c;cxx;rc;def;r;odl;idl;hpj;bat</Extensions>
-    </Filter>
-    <Filter Include="Header Files">
-      <UniqueIdentifier>{7d5fe7b3-fe1a-4aac-bf30-149a7fc653da}</UniqueIdentifier>
-      <Extensions>h;hpp;hxx;hm;inl</Extensions>
-    </Filter>
-    <Filter Include="Resource Files">
-      <UniqueIdentifier>{dee9bab8-3306-4795-9a0a-1d0a43037c65}</UniqueIdentifier>
-      <Extensions>ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe</Extensions>
-    </Filter>
+    <ClCompile Include="IpDropDown.cpp"/>
+    <ClCompile Include="VolList.cpp"/>
+    <ClCompile Include="IniModuleLoader.cpp"/>
+    <ClCompile Include="FileSystemHelper.cpp"/>
+    <ClCompile Include="GlobalDefines.cpp"/>
+    <ClCompile Include="OP2Memory.cpp"/>
+    <ClCompile Include="ConsoleModuleLoader.cpp"/>
+    <ClCompile Include="op2ext-Internal.cpp"/>
+    <ClCompile Include="Logger.cpp"/>
+    <ClCompile Include="WindowsModule.cpp"/>
+    <ClCompile Include="WindowsErrorCode.cpp"/>
+    <ClCompile Include="StringConversion.cpp"/>
+    <ClCompile Include="ConsoleArgumentParser.cpp"/>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="IpDropDown.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="VolList.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="IniModuleLoader.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="FileSystemHelper.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="GlobalDefines.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="OP2Memory.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ConsoleModuleLoader.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="op2ext-Internal.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Logger.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="WindowsModule.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="WindowsErrorCode.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="StringConversion.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="ConsoleArgumentParser.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ClInclude Include="IpDropDown.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="VolList.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="IniModuleLoader.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="FileSystemHelper.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="GlobalDefines.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="OP2Memory.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ConsoleModuleLoader.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="op2ext-Internal.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Logger.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="WindowsModule.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="WindowsErrorCode.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="StringConversion.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="ConsoleArgumentParser.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <ClInclude Include="IpDropDown.h"/>
+    <ClInclude Include="VolList.h"/>
+    <ClInclude Include="IniModuleLoader.h"/>
+    <ClInclude Include="FileSystemHelper.h"/>
+    <ClInclude Include="GlobalDefines.h"/>
+    <ClInclude Include="OP2Memory.h"/>
+    <ClInclude Include="ConsoleModuleLoader.h"/>
+    <ClInclude Include="op2ext-Internal.h"/>
+    <ClInclude Include="Logger.h"/>
+    <ClInclude Include="WindowsModule.h"/>
+    <ClInclude Include="WindowsErrorCode.h"/>
+    <ClInclude Include="StringConversion.h"/>
+    <ClInclude Include="ConsoleArgumentParser.h"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It is easier to work with the headers and cpp files when they are next to each other instead of in different filters. Also, want to sort files by actual directory location in future, not by filters.