### PR TITLE
Update command line parsing

### DIFF
--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -3,6 +3,7 @@
 #include "StringConversion.h"
 #include "FileSystemHelper.h"
 #include "GlobalDefines.h"
+#include <stdexcept>
 
 
 std::vector<std::string> GetCommandLineArguments();
@@ -24,18 +25,22 @@ std::string FindModuleDirectory()
 
 std::string FindModuleDirectory(std::vector<std::string> arguments)
 {
-	const std::string switchName = GetSwitch(arguments);
+	try {
+		const std::string switchName = GetSwitch(arguments);
 
-	if (switchName.empty()) {
-		return std::string();
+		if (switchName.empty()) {
+			return std::string();
+		}
+
+		if (switchName == "loadmod") {
+			return ParseLoadModCommand(arguments);
+		}
+
+		throw std::runtime_error("Provided switch is not supported: " + switchName);
+	} catch(const std::exception& e) {
+		PostErrorMessage(__FILE__, __LINE__, "Error parsing command line arguments: " + std::string(e.what()));
+		return "";
 	}
-
-	if (switchName == "loadmod") {
-		return ParseLoadModCommand(arguments);
-	}
-
-	PostErrorMessage(__FILE__, __LINE__, "Provided switch is not supported: " + switchName);
-	return std::string();
 }
 
 std::string GetSwitch(std::vector<std::string>& arguments)

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -13,8 +13,13 @@ std::string ParseLoadModCommand(std::vector<std::string> arguments);
 
 std::string FindModuleDirectory()
 {
-	const auto arguments = GetCommandLineArguments();
-	return FindModuleDirectory(arguments);
+	try {
+		const auto arguments = GetCommandLineArguments();
+		return FindModuleDirectory(arguments);
+	} catch(const std::exception& e) {
+		PostErrorMessage(__FILE__, __LINE__, "Error parsing command line arguments: " + std::string(e.what()));
+		return "";
+	}
 }
 
 std::string FindModuleDirectory(std::vector<std::string> arguments)

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -25,22 +25,17 @@ std::string FindModuleDirectory()
 
 std::string FindModuleDirectory(std::vector<std::string> arguments)
 {
-	try {
-		const std::string switchName = GetSwitch(arguments);
+	const std::string switchName = GetSwitch(arguments);
 
-		if (switchName.empty()) {
-			return "";
-		}
-
-		if (switchName == "loadmod") {
-			return ParseLoadModCommand(arguments);
-		}
-
-		throw std::runtime_error("Provided switch is not supported: " + switchName);
-	} catch(const std::exception& e) {
-		PostErrorMessage(__FILE__, __LINE__, "Error parsing command line arguments: " + std::string(e.what()));
+	if (switchName.empty()) {
 		return "";
 	}
+
+	if (switchName == "loadmod") {
+		return ParseLoadModCommand(arguments);
+	}
+
+	throw std::runtime_error("Provided switch is not supported: " + switchName);
 }
 
 std::string GetSwitch(std::vector<std::string>& arguments)

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -57,7 +57,7 @@ std::vector<std::string> GetCommandLineArguments()
 		}
 		// Catch STL produced exceptions
 		catch (const std::exception& e) {
-			PostErrorMessage(__FILE__, __LINE__, "Error occurred attempting to parse command line arguments. Further parshing of command line arguments aborted. Internal Error: " + std::string(e.what()));
+			PostErrorMessage(__FILE__, __LINE__, "Error occurred attempting to parse command line arguments. Further parsing of command line arguments aborted. Internal Error: " + std::string(e.what()));
 		}
 	}
 

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -61,7 +61,6 @@ std::string ParseSwitchName(std::string switchName)
 	if (switchName[0] != '/' && switchName[0] != '-') {
 		const std::string message("A switch was expected but not found. Prefix switch name with '/' or '-'. The following statement was found instead: " + switchName);
 		throw std::runtime_error(message);
-		return std::string();
 	}
 
 	switchName.erase(switchName.begin(), switchName.begin() + 1); //Removes leading - or /
@@ -74,12 +73,10 @@ std::string ParseLoadModCommand(std::vector<std::string> arguments)
 {
 	if (arguments.empty()) {
 		throw std::runtime_error("No relative directory argument provided for the switch loadmod");
-		return std::string();
 	}
 
 	if (arguments.size() > 1) {
 		throw std::runtime_error("Too many arguments passed into switch LoadMod. If module relative directory contains spaces, surround the directory in quotes");
-		return std::string();
 	}
 
 	return arguments[0];

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -19,7 +19,7 @@ std::string FindModuleDirectory()
 		return FindModuleDirectory(arguments);
 	} catch(const std::exception& e) {
 		PostErrorMessage(__FILE__, __LINE__, "Error parsing command line arguments: " + std::string(e.what()));
-		return "";
+		return std::string();
 	}
 }
 
@@ -28,7 +28,7 @@ std::string FindModuleDirectory(std::vector<std::string> arguments)
 	const std::string switchName = GetSwitch(arguments);
 
 	if (switchName.empty()) {
-		return "";
+		return std::string();
 	}
 
 	if (switchName == "loadmod") {
@@ -41,7 +41,7 @@ std::string FindModuleDirectory(std::vector<std::string> arguments)
 std::string GetSwitch(std::vector<std::string>& arguments)
 {
 	if (arguments.size() == 0) {
-		return ""; // Switch is not present
+		return std::string(); // Switch is not present
 	}
 
 	const std::string rawSwitch = arguments[0];

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -1,8 +1,8 @@
+#include "GetCommandLineArguments.h"
 #include "ConsoleArgumentParser.h"
 #include "StringConversion.h"
 #include "FileSystemHelper.h"
 #include "GlobalDefines.h"
-#include <windows.h> // Cannot use WIN32_LEAN_AND_MEAN (it does not contain CommandLineToArgvW)
 
 
 std::vector<std::string> GetCommandLineArguments();
@@ -31,38 +31,6 @@ std::string FindModuleDirectory(std::vector<std::string> arguments)
 
 	PostErrorMessage(__FILE__, __LINE__, "Provided switch is not supported: " + switchName);
 	return std::string();
-}
-
-std::vector<std::string> GetCommandLineArguments()
-{
-	std::vector<std::string> arguments;
-	int argumentCount;
-	LPWSTR* commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
-
-	if (commandLineArgs == nullptr) {
-		PostErrorMessage(__FILE__, __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
-	}
-	else {
-		try {
-			// Ignore the first argument, which is the path of the executable.
-			for (int i = 1; i < argumentCount; ++i) {
-				std::string argument;
-				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
-					PostErrorMessage(__FILE__, __LINE__, "Unable to cast the " + std::to_string(i) +
-						" command line argument from LPWSTR to char*. Further parsing of command line arguments aborted.");
-					break;
-				}
-				arguments.push_back(argument);
-			}
-		}
-		// Catch STL produced exceptions
-		catch (const std::exception& e) {
-			PostErrorMessage(__FILE__, __LINE__, "Error occurred attempting to parse command line arguments. Further parsing of command line arguments aborted. Internal Error: " + std::string(e.what()));
-		}
-	}
-
-	LocalFree(commandLineArgs);
-	return arguments;
 }
 
 std::string GetSwitch(std::vector<std::string>& arguments)

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -60,7 +60,7 @@ std::string ParseSwitchName(std::string switchName)
 {
 	if (switchName[0] != '/' && switchName[0] != '-') {
 		const std::string message("A switch was expected but not found. Prefix switch name with '/' or '-'. The following statement was found instead: " + switchName);
-		PostErrorMessage(__FILE__, __LINE__, message);
+		throw std::runtime_error(message);
 		return std::string();
 	}
 
@@ -73,12 +73,12 @@ std::string ParseSwitchName(std::string switchName)
 std::string ParseLoadModCommand(std::vector<std::string> arguments)
 {
 	if (arguments.empty()) {
-		PostErrorMessage(__FILE__, __LINE__, "No relative directory argument provided for the switch loadmod");
+		throw std::runtime_error("No relative directory argument provided for the switch loadmod");
 		return std::string();
 	}
 
 	if (arguments.size() > 1) {
-		PostErrorMessage(__FILE__, __LINE__, "Too many arguments passed into switch LoadMod. If module relative directory contains spaces, surround the directory in quotes");
+		throw std::runtime_error("Too many arguments passed into switch LoadMod. If module relative directory contains spaces, surround the directory in quotes");
 		return std::string();
 	}
 

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -29,7 +29,7 @@ std::string FindModuleDirectory(std::vector<std::string> arguments)
 		const std::string switchName = GetSwitch(arguments);
 
 		if (switchName.empty()) {
-			return std::string();
+			return "";
 		}
 
 		if (switchName == "loadmod") {
@@ -46,7 +46,7 @@ std::string FindModuleDirectory(std::vector<std::string> arguments)
 std::string GetSwitch(std::vector<std::string>& arguments)
 {
 	if (arguments.size() == 0) {
-		return std::string(); // Switch is not present
+		return ""; // Switch is not present
 	}
 
 	const std::string rawSwitch = arguments[0];

--- a/srcStatic/GetCommandLineArguments.cpp
+++ b/srcStatic/GetCommandLineArguments.cpp
@@ -20,7 +20,6 @@ std::vector<std::string> GetCommandLineArguments()
 			std::string argument;
 			if (!ConvertLPWToString(argument, commandLineArgs[i])) {
 				throw std::runtime_error("Unable to convert command line argument from LPWSTR to std::string. Argument index: " + std::to_string(i));
-				break;
 			}
 			arguments.push_back(argument);
 		}

--- a/srcStatic/GetCommandLineArguments.cpp
+++ b/srcStatic/GetCommandLineArguments.cpp
@@ -9,7 +9,7 @@ std::vector<std::string> GetCommandLineArguments()
 {
 	std::vector<std::string> arguments;
 	int argumentCount;
-	LocalResource<LPWSTR> commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
+	LocalResource<LPWSTR*> commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
 
 	if (commandLineArgs == nullptr) {
 		throw std::runtime_error("Unable to retrieve command line arguments attached to Outpost2.exe.");

--- a/srcStatic/GetCommandLineArguments.cpp
+++ b/srcStatic/GetCommandLineArguments.cpp
@@ -15,20 +15,14 @@ std::vector<std::string> GetCommandLineArguments()
 		throw std::runtime_error("Unable to retrieve command line arguments attached to Outpost2.exe.");
 	}
 	else {
-		try {
-			// Ignore the first argument, which is the path of the executable.
-			for (int i = 1; i < argumentCount; ++i) {
-				std::string argument;
-				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
-					throw std::runtime_error("Unable to convert command line argument from LPWSTR to std::string. Argument index: " + std::to_string(i));
-					break;
-				}
-				arguments.push_back(argument);
+		// Ignore the first argument, which is the path of the executable.
+		for (int i = 1; i < argumentCount; ++i) {
+			std::string argument;
+			if (!ConvertLPWToString(argument, commandLineArgs[i])) {
+				throw std::runtime_error("Unable to convert command line argument from LPWSTR to std::string. Argument index: " + std::to_string(i));
+				break;
 			}
-		}
-		// Catch STL produced exceptions
-		catch (const std::exception& e) {
-			throw std::runtime_error("Error parsing command line arguments. Internal Error: " + std::string(e.what()));
+			arguments.push_back(argument);
 		}
 	}
 

--- a/srcStatic/GetCommandLineArguments.cpp
+++ b/srcStatic/GetCommandLineArguments.cpp
@@ -1,0 +1,37 @@
+#include "GetCommandLineArguments.h"
+#include "StringConversion.h"
+#include "GlobalDefines.h"
+#include <windows.h> // Cannot use WIN32_LEAN_AND_MEAN (it does not contain CommandLineToArgvW)
+
+
+std::vector<std::string> GetCommandLineArguments()
+{
+	std::vector<std::string> arguments;
+	int argumentCount;
+	LPWSTR* commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
+
+	if (commandLineArgs == nullptr) {
+		PostErrorMessage(__FILE__, __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
+	}
+	else {
+		try {
+			// Ignore the first argument, which is the path of the executable.
+			for (int i = 1; i < argumentCount; ++i) {
+				std::string argument;
+				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
+					PostErrorMessage(__FILE__, __LINE__, "Unable to cast the " + std::to_string(i) +
+						" command line argument from LPWSTR to char*. Further parsing of command line arguments aborted.");
+					break;
+				}
+				arguments.push_back(argument);
+			}
+		}
+		// Catch STL produced exceptions
+		catch (const std::exception& e) {
+			PostErrorMessage(__FILE__, __LINE__, "Error occurred attempting to parse command line arguments. Further parsing of command line arguments aborted. Internal Error: " + std::string(e.what()));
+		}
+	}
+
+	LocalFree(commandLineArgs);
+	return arguments;
+}

--- a/srcStatic/GetCommandLineArguments.cpp
+++ b/srcStatic/GetCommandLineArguments.cpp
@@ -1,5 +1,6 @@
 #include "GetCommandLineArguments.h"
 #include "StringConversion.h"
+#include "LocalResource.h"
 #include "GlobalDefines.h"
 #include <windows.h> // Cannot use WIN32_LEAN_AND_MEAN (it does not contain CommandLineToArgvW)
 
@@ -8,7 +9,7 @@ std::vector<std::string> GetCommandLineArguments()
 {
 	std::vector<std::string> arguments;
 	int argumentCount;
-	LPWSTR* commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
+	LocalResource<LPWSTR> commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
 
 	if (commandLineArgs == nullptr) {
 		PostErrorMessage(__FILE__, __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
@@ -32,6 +33,5 @@ std::vector<std::string> GetCommandLineArguments()
 		}
 	}
 
-	LocalFree(commandLineArgs);
 	return arguments;
 }

--- a/srcStatic/GetCommandLineArguments.cpp
+++ b/srcStatic/GetCommandLineArguments.cpp
@@ -1,8 +1,8 @@
 #include "GetCommandLineArguments.h"
 #include "StringConversion.h"
 #include "LocalResource.h"
-#include "GlobalDefines.h"
 #include <windows.h> // Cannot use WIN32_LEAN_AND_MEAN (it does not contain CommandLineToArgvW)
+#include <stdexcept>
 
 
 std::vector<std::string> GetCommandLineArguments()
@@ -12,7 +12,7 @@ std::vector<std::string> GetCommandLineArguments()
 	LocalResource<LPWSTR> commandLineArgs = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
 
 	if (commandLineArgs == nullptr) {
-		PostErrorMessage(__FILE__, __LINE__, "Unable to retrieve command line arguments attached to Outpost2.exe.");
+		throw std::runtime_error("Unable to retrieve command line arguments attached to Outpost2.exe.");
 	}
 	else {
 		try {
@@ -20,8 +20,7 @@ std::vector<std::string> GetCommandLineArguments()
 			for (int i = 1; i < argumentCount; ++i) {
 				std::string argument;
 				if (!ConvertLPWToString(argument, commandLineArgs[i])) {
-					PostErrorMessage(__FILE__, __LINE__, "Unable to cast the " + std::to_string(i) +
-						" command line argument from LPWSTR to char*. Further parsing of command line arguments aborted.");
+					throw std::runtime_error("Unable to convert command line argument from LPWSTR to std::string. Argument index: " + std::to_string(i));
 					break;
 				}
 				arguments.push_back(argument);
@@ -29,7 +28,7 @@ std::vector<std::string> GetCommandLineArguments()
 		}
 		// Catch STL produced exceptions
 		catch (const std::exception& e) {
-			PostErrorMessage(__FILE__, __LINE__, "Error occurred attempting to parse command line arguments. Further parsing of command line arguments aborted. Internal Error: " + std::string(e.what()));
+			throw std::runtime_error("Error parsing command line arguments. Internal Error: " + std::string(e.what()));
 		}
 	}
 

--- a/srcStatic/GetCommandLineArguments.h
+++ b/srcStatic/GetCommandLineArguments.h
@@ -1,0 +1,4 @@
+#include <string>
+#include <vector>
+
+std::vector<std::string> GetCommandLineArguments();

--- a/srcStatic/LocalResource.h
+++ b/srcStatic/LocalResource.h
@@ -1,9 +1,12 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <type_traits>
+
 
 // RAII management of LocalAlloc/LocalFree resources
 template <typename T>
 class LocalResource {
+	static_assert(std::is_pointer<T>::value, "Type must be a pointer");
 public:
 	LocalResource(T pointer) : pointer(pointer) {
 	}

--- a/srcStatic/LocalResource.h
+++ b/srcStatic/LocalResource.h
@@ -5,7 +5,7 @@
 template <typename T>
 class LocalResource {
 public:
-	LocalResource(T* pointer) : pointer(pointer) {
+	LocalResource(T pointer) : pointer(pointer) {
 	}
 	~LocalResource() {
 		// Freeing of NULL is safe
@@ -13,9 +13,9 @@ public:
 	}
 
 	// Auto convert to underlying pointer type
-	operator T*() const {
+	operator T() const {
 		return pointer;
 	}
 private:
-	T* pointer;
+	T pointer;
 };

--- a/srcStatic/LocalResource.h
+++ b/srcStatic/LocalResource.h
@@ -1,0 +1,21 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+// RAII management of LocalAlloc/LocalFree resources
+template <typename T>
+class LocalResource {
+public:
+	LocalResource(T* pointer) : pointer(pointer) {
+	}
+	~LocalResource() {
+		// Freeing of NULL is safe
+		LocalFree(pointer);
+	}
+
+	// Auto convert to underlying pointer type
+	operator T*() const {
+		return pointer;
+	}
+private:
+	T* pointer;
+};

--- a/srcStatic/LocalResource.h
+++ b/srcStatic/LocalResource.h
@@ -8,6 +8,8 @@ template <typename T>
 class LocalResource {
 	static_assert(std::is_pointer<T>::value, "Type must be a pointer");
 public:
+	LocalResource() : resource(NULL) {
+	}
 	LocalResource(T resource) : resource(resource) {
 	}
 	~LocalResource() {

--- a/srcStatic/LocalResource.h
+++ b/srcStatic/LocalResource.h
@@ -8,17 +8,17 @@ template <typename T>
 class LocalResource {
 	static_assert(std::is_pointer<T>::value, "Type must be a pointer");
 public:
-	LocalResource(T pointer) : pointer(pointer) {
+	LocalResource(T resource) : resource(resource) {
 	}
 	~LocalResource() {
 		// Freeing of NULL is safe
-		LocalFree(pointer);
+		LocalFree(resource);
 	}
 
-	// Auto convert to underlying pointer type
+	// Auto convert to underlying type
 	operator T() const {
-		return pointer;
+		return resource;
 	}
 private:
-	T pointer;
+	T resource;
 };

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -123,6 +123,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="GetCommandLineArguments.cpp" />
     <ClCompile Include="ConsoleArgumentParser.cpp" />
     <ClCompile Include="FileSystemHelper.cpp" />
     <ClCompile Include="GlobalDefines.cpp" />
@@ -138,6 +139,7 @@
     <ClCompile Include="WindowsModule.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="GetCommandLineArguments.h" />
     <ClInclude Include="ConsoleArgumentParser.h" />
     <ClInclude Include="FileSystemHelper.h" />
     <ClInclude Include="GlobalDefines.h" />

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -14,6 +14,7 @@
     <ClCompile Include="WindowsErrorCode.cpp"/>
     <ClCompile Include="StringConversion.cpp"/>
     <ClCompile Include="ConsoleArgumentParser.cpp"/>
+    <ClCompile Include="GetCommandLineArguments.cpp"/>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="IpDropDown.h"/>
@@ -29,5 +30,6 @@
     <ClInclude Include="WindowsErrorCode.h"/>
     <ClInclude Include="StringConversion.h"/>
     <ClInclude Include="ConsoleArgumentParser.h"/>
+    <ClInclude Include="GetCommandLineArguments.h"/>
   </ItemGroup>
 </Project>

--- a/test/ConsoleArgumentParser.test.cpp
+++ b/test/ConsoleArgumentParser.test.cpp
@@ -11,19 +11,19 @@
 
 
 TEST(ConsoleArgumentParser, NoArgument) {
-	EXPECT_FALSE(FindModuleDirectoryIsLogged(std::vector<std::string> { }, ""));
+	EXPECT_EQ("", FindModuleDirectory(std::vector<std::string> { }));
 }
 
 TEST(ConsoleArgumentParser, WellFormedNoSpaces)
 {
 	const std::string path("path");
-	EXPECT_FALSE(FindModuleDirectoryIsLogged(std::vector<std::string> { "/loadmod", path}, path));
+	EXPECT_EQ(path, FindModuleDirectory(std::vector<std::string> { "/loadmod", path }));
 }
 
 TEST(ConsoleArgmunetParser, WellFormedSpaces)
 {
 	const std::string pathWithSpaces("path with spaces");
-	EXPECT_FALSE(FindModuleDirectoryIsLogged(std::vector<std::string> { "/loadmod", pathWithSpaces }, pathWithSpaces));
+	EXPECT_EQ(pathWithSpaces, FindModuleDirectory(std::vector<std::string> { "/loadmod", pathWithSpaces }));
 }
 
 

--- a/test/ConsoleArgumentParser.test.cpp
+++ b/test/ConsoleArgumentParser.test.cpp
@@ -7,8 +7,6 @@
 #include <cstdint>
 #include <functional>
 
-::testing::AssertionResult FindModuleDirectoryIsLogged(const std::vector<std::string>& arguments, const std::string& expectResult);
-
 
 TEST(ConsoleArgumentParser, NoArgument) {
 	EXPECT_EQ("", FindModuleDirectory(std::vector<std::string> { }));
@@ -37,21 +35,4 @@ TEST(ConsoleArgumentParser, NoSwitchArgument) {
 
 TEST(ConsoleArgumentParser, TooManyArguments) {
 	EXPECT_THROW(FindModuleDirectory(std::vector<std::string> { "/loadmod", "path1", "path2" }), std::runtime_error);
-}
-
-
-// Returns true if calling FindModuleDirectory provides input to the logger by checking log size
-::testing::AssertionResult FindModuleDirectoryIsLogged(
-	const std::vector<std::string>& arguments, const std::string& expectResult)
-{
-	const auto logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
-	const uintmax_t preFileSize = fs::file_size(logPath);
-
-	EXPECT_EQ(expectResult, FindModuleDirectory(arguments));
-
-	if (fs::file_size(logPath) > preFileSize) {
-		return ::testing::AssertionSuccess() << "Message logged";
-	}
-
-	return ::testing::AssertionFailure() << "Message not logged";
 }

--- a/test/ConsoleArgumentParser.test.cpp
+++ b/test/ConsoleArgumentParser.test.cpp
@@ -16,8 +16,8 @@ TEST(ConsoleArgumentParser, WellFormedNoSpaces)
 
 TEST(ConsoleArgmunetParser, WellFormedSpaces)
 {
-	const std::string pathWithSpaces("path with spaces");
-	EXPECT_EQ(pathWithSpaces, FindModuleDirectory(std::vector<std::string> { "/loadmod", pathWithSpaces }));
+	const std::string path("path with spaces");
+	EXPECT_EQ(path, FindModuleDirectory(std::vector<std::string> { "/loadmod", path }));
 }
 
 

--- a/test/ConsoleArgumentParser.test.cpp
+++ b/test/ConsoleArgumentParser.test.cpp
@@ -1,11 +1,7 @@
-#include "op2ext-Internal.h"
 #include "ConsoleArgumentParser.h"
-#include "FileSystemHelper.h"
 #include <gtest/gtest.h>
 #include <vector>
 #include <string>
-#include <cstdint>
-#include <functional>
 
 
 TEST(ConsoleArgumentParser, NoArgument) {

--- a/test/ConsoleArgumentParser.test.cpp
+++ b/test/ConsoleArgumentParser.test.cpp
@@ -28,15 +28,15 @@ TEST(ConsoleArgmunetParser, WellFormedSpaces)
 
 
 TEST(ConsoleArgumentParser, WrongSwitchName) {
-	EXPECT_TRUE(FindModuleDirectoryIsLogged(std::vector<std::string> { "/WrongSwitch" }, ""));
+	EXPECT_THROW(FindModuleDirectory(std::vector<std::string> { "/WrongSwitch" }), std::runtime_error);
 }
 
 TEST(ConsoleArgumentParser, NoSwitchArgument) {
-	EXPECT_TRUE(FindModuleDirectoryIsLogged(std::vector<std::string> { "/loadmod" }, ""));
+	EXPECT_THROW(FindModuleDirectory(std::vector<std::string> { "/loadmod" }), std::runtime_error);
 }
 
 TEST(ConsoleArgumentParser, TooManyArguments) {
-	EXPECT_TRUE(FindModuleDirectoryIsLogged(std::vector<std::string> { "/loadmod", "path1", "path2" }, ""));
+	EXPECT_THROW(FindModuleDirectory(std::vector<std::string> { "/loadmod", "path1", "path2" }), std::runtime_error);
 }
 
 


### PR DESCRIPTION
This updates the command line argument processing code to make it more testable. Errors are reported with exceptions, which are now only caught and logged at a higher level. This means unit tests no longer have to muck about with the log file to check for error reporting.

This cleanup is meant to help with Issue #100.
