### PR TITLE
Update windows error reporting

### DIFF
--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -94,7 +94,7 @@ void ConsoleModuleLoader::LoadModuleDll()
 	}
 	else {
 		const std::string errorMessage("Unable to load console module's dll from " + dllName +
-			". " + GetLastErrorStdString("LoadLibrary"));
+			". " + GetLastErrorString("LoadLibrary"));
 
 		PostErrorMessage(__FILE__, __LINE__, errorMessage);
 	}

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -94,7 +94,7 @@ void ConsoleModuleLoader::LoadModuleDll()
 	}
 	else {
 		const std::string errorMessage("Unable to load console module's dll from " + dllName +
-			". " + GetLastErrorStdString(TEXT("LoadLibrary")));
+			". " + GetLastErrorStdString("LoadLibrary"));
 
 		PostErrorMessage(__FILE__, __LINE__, errorMessage);
 	}

--- a/srcStatic/IniModuleLoader.cpp
+++ b/srcStatic/IniModuleLoader.cpp
@@ -95,7 +95,7 @@ HINSTANCE IniModuleLoader::LoadModuleDll(const std::string& sectionName)
 
 	if (dllHandle == 0) {
 		throw std::runtime_error("Unable to load DLL " + dllName + " from ini module section " +
-			sectionName + "." + GetLastErrorStdString("LoadLibrary"));
+			sectionName + "." + GetLastErrorString("LoadLibrary"));
 	}
 
 	return dllHandle;

--- a/srcStatic/IniModuleLoader.cpp
+++ b/srcStatic/IniModuleLoader.cpp
@@ -95,7 +95,7 @@ HINSTANCE IniModuleLoader::LoadModuleDll(const std::string& sectionName)
 
 	if (dllHandle == 0) {
 		throw std::runtime_error("Unable to load DLL " + dllName + " from ini module section " +
-			sectionName + "." + GetLastErrorStdString(TEXT("LoadLibrary")));
+			sectionName + "." + GetLastErrorStdString("LoadLibrary"));
 	}
 
 	return dllHandle;

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -4,8 +4,6 @@
 
 std::string GetLastErrorString(std::string functionName)
 {
-	// Adapted from https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-the-last-error-code
-
 	LPTSTR lpMsgBuf;
 	DWORD lastErrorCode = GetLastError();
 

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -7,14 +7,14 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 	// Adapted from https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-the-last-error-code
 
 	LPTSTR lpMsgBuf;
-	DWORD dw = GetLastError();
+	DWORD lastErrorCode = GetLastError();
 
 	FormatMessage(
 		FORMAT_MESSAGE_ALLOCATE_BUFFER |
 		FORMAT_MESSAGE_FROM_SYSTEM |
 		FORMAT_MESSAGE_IGNORE_INSERTS,
 		NULL,
-		dw,
+		lastErrorCode,
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 		reinterpret_cast<LPTSTR>(&lpMsgBuf),
 		0,
@@ -32,7 +32,7 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 		lpDisplayBuf,
 		LocalSize(lpDisplayBuf) / sizeof(TCHAR),
 		TEXT("%s failed with error %d: %s"),
-		lpszFunction, dw, lpMsgBuf
+		lpszFunction, lastErrorCode, lpMsgBuf
 	);
 
 	std::string errorMessage = ConvertLpctstrToString(lpDisplayBuf);

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -1,6 +1,5 @@
 #include "WindowsErrorCode.h"
 #include "StringConversion.h"
-#include <strsafe.h> //Header requires WindowsXP SP2 or greater
 
 std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 {
@@ -21,24 +20,12 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 		NULL
 	);
 
-	LPTSTR lpDisplayBuf = static_cast<LPTSTR>(
-		LocalAlloc(
-			LMEM_ZEROINIT,
-			(lstrlen(lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR)
-		)
-	);
+	auto errorCodeMessage = ConvertLpctstrToString(lpMsgBuf);
+	auto functionName = ConvertLpctstrToString(lpszFunction);
 
-	StringCchPrintf(
-		lpDisplayBuf,
-		LocalSize(lpDisplayBuf) / sizeof(TCHAR),
-		TEXT("%s failed with error %d: %s"),
-		lpszFunction, lastErrorCode, lpMsgBuf
-	);
-
-	std::string errorMessage = ConvertLpctstrToString(lpDisplayBuf);
+	auto errorMessage = functionName + " failed with error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
 
 	LocalFree(lpMsgBuf);
-	LocalFree(lpDisplayBuf);
 
 	return errorMessage;
 }

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -22,7 +22,6 @@ std::string GetLastErrorString(std::string functionName)
 	);
 
 	auto errorCodeMessage = ConvertLpctstrToString(lpMsgBuf);
-
 	auto errorMessage = functionName + " failed with error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
 
 	LocalFree(lpMsgBuf);

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -1,7 +1,7 @@
 #include "WindowsErrorCode.h"
 #include "StringConversion.h"
 
-std::string GetLastErrorStdString(LPCTSTR lpszFunction)
+std::string GetLastErrorStdString(std::string functionName)
 {
 	// Adapted from https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-the-last-error-code
 
@@ -21,7 +21,6 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 	);
 
 	auto errorCodeMessage = ConvertLpctstrToString(lpMsgBuf);
-	auto functionName = ConvertLpctstrToString(lpszFunction);
 
 	auto errorMessage = functionName + " failed with error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
 

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -2,7 +2,7 @@
 #include "StringConversion.h"
 #include <windows.h>
 
-std::string GetLastErrorStdString(std::string functionName)
+std::string GetLastErrorString(std::string functionName)
 {
 	// Adapted from https://docs.microsoft.com/en-us/windows/desktop/Debug/retrieving-the-last-error-code
 

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -17,15 +17,23 @@ std::string GetLastErrorStdString(LPCTSTR lpszFunction)
 		dw,
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 		reinterpret_cast<LPTSTR>(&lpMsgBuf),
-		0, NULL);
+		0,
+		NULL
+	);
 
-	LPTSTR lpDisplayBuf = static_cast<LPTSTR>(LocalAlloc(LMEM_ZEROINIT,
-		(lstrlen(lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR)));
+	LPTSTR lpDisplayBuf = static_cast<LPTSTR>(
+		LocalAlloc(
+			LMEM_ZEROINIT,
+			(lstrlen(lpMsgBuf) + lstrlen(lpszFunction) + 40) * sizeof(TCHAR)
+		)
+	);
 
-	StringCchPrintf(lpDisplayBuf,
+	StringCchPrintf(
+		lpDisplayBuf,
 		LocalSize(lpDisplayBuf) / sizeof(TCHAR),
 		TEXT("%s failed with error %d: %s"),
-		lpszFunction, dw, lpMsgBuf);
+		lpszFunction, dw, lpMsgBuf
+	);
 
 	std::string errorMessage = ConvertLpctstrToString(lpDisplayBuf);
 

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -1,5 +1,6 @@
 #include "WindowsErrorCode.h"
 #include "StringConversion.h"
+#include <windows.h>
 
 std::string GetLastErrorStdString(std::string functionName)
 {

--- a/srcStatic/WindowsErrorCode.h
+++ b/srcStatic/WindowsErrorCode.h
@@ -3,4 +3,4 @@
 #include <string>
 
 // Retrieve the system error message for the last-error code
-std::string GetLastErrorStdString(LPCTSTR lpszFunction);
+std::string GetLastErrorStdString(std::string functionName);

--- a/srcStatic/WindowsErrorCode.h
+++ b/srcStatic/WindowsErrorCode.h
@@ -2,4 +2,4 @@
 #include <string>
 
 // Retrieve the system error message for the last-error code
-std::string GetLastErrorStdString(std::string functionName);
+std::string GetLastErrorString(std::string functionName);

--- a/srcStatic/WindowsErrorCode.h
+++ b/srcStatic/WindowsErrorCode.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <windows.h>
 #include <string>
 
 // Retrieve the system error message for the last-error code


### PR DESCRIPTION
This cleans up the `GetLastErrorString` function, and improves the interface slightly.

----

Potential future work:

There is still one use of a local buffer that must be freed with `LocalFree`, which is not handled in an exception safe manner. If the `std::string` methods throw, perhaps due to memory exhaustion, we would be leaking that memory. In PR #126, there was a `LocalResource` class that was added to handle such resources in an exception safe way using RAII. We could potentially use it here, though it seems it's going to need a little bit of work to add a few extra needed features.

The calls to `GetLastErrorString` could potentially do more of the string formatting. We probably don't actually need to pass the `functionName` parameter. That part of the formatting could be handled by the caller. It's also questionable if we really need the error code number in the error message. Removing both could simplify the method and make it much more highly targeted. Would love some feedback on that idea.
