### PR TITLE
Make `GetLastErrorString` exception safe

### DIFF
--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -1,10 +1,11 @@
 #include "WindowsErrorCode.h"
 #include "StringConversion.h"
+#include "LocalResource.h"
 #include <windows.h>
 
 std::string GetLastErrorString(std::string functionName)
 {
-	LPTSTR lpMsgBuf;
+	LocalResource<LPTSTR> lpMsgBuf;
 	DWORD lastErrorCode = GetLastError();
 
 	FormatMessage(
@@ -21,8 +22,6 @@ std::string GetLastErrorString(std::string functionName)
 
 	auto errorCodeMessage = ConvertLpctstrToString(lpMsgBuf);
 	auto errorMessage = functionName + " failed with error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
-
-	LocalFree(lpMsgBuf);
 
 	return errorMessage;
 }


### PR DESCRIPTION
This branch only really has 1 new commit. It pulls in the changes from PR #126 and PR #127 (see the two non-fast-forward merge commits at the end), and then applies one small fix on top of that.

Not sure if there is an easier way to present this for review, other than to have waited until the other two branches are merged to master, and then rebase the work on top of that.
