### PR TITLE
Use explicit `std::string()` construction

### DIFF
--- a/srcStatic/GlobalDefines.cpp
+++ b/srcStatic/GlobalDefines.cpp
@@ -51,7 +51,7 @@ std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, 
 std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace)
 {
 	if (trimOption == TrimOption::None) {
-		return "";
+		return std::string();
 	}
 
 	std::size_t stringBegin = 0;
@@ -60,7 +60,7 @@ std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, c
 	}
 
 	if (stringBegin == std::string::npos) {
-		return ""; // no content provided
+		return std::string(); // no content provided
 	}
 
 	auto stringEnd = stringToTrim.length();

--- a/srcStatic/IniModuleLoader.cpp
+++ b/srcStatic/IniModuleLoader.cpp
@@ -58,7 +58,7 @@ bool IniModuleLoader::UnloadModules()
 std::string IniModuleLoader::GetModuleName(std::size_t index)
 {
 	if (index >= modules.size()) {
-		return "";
+		return std::string();
 	}
 
 	return modules[index].iniSectionName;


### PR DESCRIPTION
As mentioned in PR #126, using `std::string()` is more clear about type than `""`, and also performs faster under certain compiler and optimization settings. The change was made to affected code in that PR. There were however a few other instances of `return "";` in unrelated files. I've chosen to update them here.
