### PR TITLE
Case preserve `ConsoleModuleLoader::GetModuleName`

### DIFF
--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -25,7 +25,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::string& moduleRelativeDirect
 	}
 
 	moduleDirectory = fs::path(GetGameDirectory()).append(moduleRelativeDirectory).string();
-	moduleName = ToLower(moduleRelativeDirectory);
+	moduleName = moduleRelativeDirectory;
 
 	std::error_code errorCode;
 	if (!fs::is_directory(moduleDirectory, errorCode)) {
@@ -56,7 +56,7 @@ bool ConsoleModuleLoader::IsModuleLoaded(std::string moduleName)
 		return false;
 	}
 
-	return ToLowerInPlace(moduleName) == GetModuleName();
+	return ToLowerInPlace(moduleName) == ToLower(GetModuleName());
 }
 
 void ConsoleModuleLoader::LoadModule()

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -1,6 +1,5 @@
 #include "ConsoleModuleLoader.h"
 #include "FileSystemHelper.h"
-#include "StringConversion.h"
 #include <gtest/gtest.h>
 #include <string>
 
@@ -32,7 +31,7 @@ TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 
 	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
 	EXPECT_EQ(moduleDirectory, consoleModLoader.GetModuleDirectory());
-	EXPECT_EQ(ToLower(moduleName), consoleModLoader.GetModuleName());
+	EXPECT_EQ(moduleName, consoleModLoader.GetModuleName());
 
 	EXPECT_TRUE(consoleModLoader.IsModuleLoaded(moduleName));
 	EXPECT_FALSE(consoleModLoader.IsModuleLoaded(""));
@@ -52,7 +51,7 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 
 	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
 	EXPECT_EQ(moduleDirectory, consoleModLoader.GetModuleDirectory());
-	EXPECT_EQ(ToLower(moduleName), consoleModLoader.GetModuleName());
+	EXPECT_EQ(moduleName, consoleModLoader.GetModuleName());
 
 	EXPECT_TRUE(consoleModLoader.IsModuleLoaded(moduleName));
 	EXPECT_FALSE(consoleModLoader.IsModuleLoaded(""));


### PR DESCRIPTION
As calling code may query the module name, we should probably make `GetModuleName()` case preserving so they get back the exact name that was used to load the module.

----

Aside from the nice to have above, I also have an alternate agenda here. In Issue #121, the proposed solution was to add `LocateVolFiles(consoleModLoader.GetModuleName())` to the new hooked `TApp::Init()` method. That could fail on a case sensitive filesystem if the module name was not case preserving. Using `GetModuleDirectory()` instead would not work, since it returns absolute paths and `LocateVolFiles` can only take a path relative to the game folder.
