### PR TITLE
Load VOL files from console module folder

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -75,6 +75,8 @@ int TApp::Init()
 	// Load all active modules from the .ini file
 	iniModuleLoader.LoadModules();
 
+	// ConsoleModule name matches relative folder from game exeucutable folder
+	LocateVolFiles(consoleModLoader.GetModuleName());
 	LocateVolFiles("Addon");
 	LocateVolFiles(); //Searches root directory
 


### PR DESCRIPTION
This is one possible way to address Issue #121.

I have not been able to test this change. It seems any use of `/loadmod` with a valid module is affected by the Mingw code generation bug.

----

One caveat about this change, is it doesn't work exactly the way console module VOL file loading used to work before. The difference is a bit subtle, and probably not significant to any existing modules.

Previously, the VOL loader used a fixed list of VOL files, which would come from the main game folder. When a console module was loaded, the console module first was searched first, before the main game folder. In either case, it was the same fixed list of named VOL files that was loaded. This would allow console module VOL files to completely replace the built in ones of the same name. If a file was missing from the new replacement VOL file, it would effectively be deleted from the game.

The new code loads any VOL file found in the the console folder, as well as any VOL file found in the main game folder. There is no longer a fixed list. If a VOL files of the same name exist in both folders, they will both be loaded, with the console module VOL file taking priority. As both modules are now loaded, and have a priority order, it is no longer possible to delete a file from the game by providing a replacement VOL file with that file missing. The file will simply not be seen in the replacement VOL file, and search will continue into the regular built in VOL files, where it will still be found.

If this is close enough behaviour, then this should be able to close the issue.

----

Potential future work:
We may want to also loop over the INI module folders, and load any VOL files found in them too.
