### PR TITLE
Lift `UNICODE` restriction on string conversion

### DIFF
--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -3,11 +3,11 @@
 
 std::string ConvertLpctstrToString(LPCSTR str)
 {
-#if defined(UNICODE) || defined(_UNICODE)
-	throw std::runtime_error("Unicode is not supported");
-#endif
-
 	return std::string(str);
+}
+std::wstring ConvertLpctstrToString(LPCWSTR str)
+{
+	return std::wstring(str);
 }
 
 bool ConvertLPWToString(std::string& stringOut, const LPWSTR pw, UINT codepage)

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -9,8 +9,10 @@
 // Converts a LPWSTR to std::string
 bool ConvertLPWToString(std::string& stringOut, const LPWSTR pw, UINT codepage = CP_ACP);
 
-// Convert a LPCTSTR to std::string. Throws an exception if code is compiled with Unicode character set.
+// Convert a LPCTSTR to std::string
+// At compile time LPCTSTR will convert to either LPCSTR or LPCWSTR based on the UNICODE setting
 std::string ConvertLpctstrToString(LPCSTR str);
+std::wstring ConvertLpctstrToString(LPCWSTR str);
 
 // Returns 0 on success
 // Returns needed buffer size (including space for null terminator) if the destination buffer is too small

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -1,6 +1,24 @@
 #include "StringConversion.h"
 #include <gtest/gtest.h>
 #include <string>
+#include <type_traits>
+
+
+TEST(StringConversion, ConvertLpctstrToStringNarrow)
+{
+	LPCSTR rawString = "test string";
+	auto result = ConvertLpctstrToString(rawString);
+	EXPECT_EQ(rawString, result);
+	EXPECT_TRUE((std::is_same<std::string, decltype(result)>::value));
+}
+
+TEST(StringConversion, ConvertLpctstrToStringWide)
+{
+	LPCWSTR rawString = L"test string";
+	auto result = ConvertLpctstrToString(rawString);
+	EXPECT_EQ(rawString, result);
+	EXPECT_TRUE((std::is_same<std::wstring, decltype(result)>::value));
+}
 
 TEST(StringConversion, ToLower)
 {


### PR DESCRIPTION
Previously the code tried to issue a runtime exception for what was effectively a compile time error. It also provided a misleading function name in that the "T" in "LPCTSTR" meant it would adapt to changes in string width based on the `UNICODE` setting. The function however only actually provided support for narrow strings, not for wide strings.

By providing two overloads of the function, for both types of strings, the compiler will auto detect at compile time which function should be called. It also means both versions of the method could be used in the same executable, allowing support of mixed string width code. If the wrong string types are mixed together in an incompatible way, it will result in a compile time error due to the type mismatch. And finally, it means the function will finally live up to the "T" in its name.
