### PR TITLE
Logger updates

### DIFF
--- a/makefile-generic.mk
+++ b/makefile-generic.mk
@@ -248,7 +248,7 @@ gtest_DEFINES = $(gtest_$(config)_DEFINES)
 
 # To ease configuring test projects to use a local build
 gtest_LOCALBUILD_LDFLAGS = -L$(gtest_BUILDDIR)googlemock/ -L$(gtest_BUILDDIR)googlemock/gtest/
-gtest_LINK_LDLIBS := -lgtest -lgtest_main
+gtest_LINK_LDLIBS := -lgtest_main -lgtest -lgmock
 
 # To help running of unit tests
 gtest_mingw_RUNPREFIX := wine

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -5,6 +5,7 @@
 #include "GlobalDefines.h"
 #include "op2ext-Internal.h"
 #include "Log.h"
+#include "LoggerFile.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
@@ -34,10 +35,22 @@ public:
 DWORD* loadLibraryDataAddr = (DWORD*)0x00486E0A;
 DWORD loadLibraryNewAddr = (DWORD)LoadLibraryNew;
 
+// Warning: globals requiring dynamic initialization
+// Dynamic initialization order between translation units is unsequenced
+// Globals from other files should not use these before DllMain has started
+// Similarly these should not use globals from other files before DllMain has started
+// Pay careful attention to anything passed to a constructor, or called by a constructor
+LoggerFile loggerFile; // Logging to file in Outpost 2 folder
+
+
 BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 {
 	// This will be called once the program is unpacked and running
 	if (dwReason == DLL_PROCESS_ATTACH) {
+		// Setup logging
+		SetLogger(&loggerFile);
+
+		// Set load offset for Outpost2.exe module, used during memory patching
 		SetLoadOffset();
 
 		// Replace call to gTApp.Init with custom routine

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -4,6 +4,7 @@
 #include "FileSystemHelper.h"
 #include "GlobalDefines.h"
 #include "op2ext-Internal.h"
+#include "Log.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
@@ -124,7 +125,7 @@ void LocateVolFiles(const std::string& relativeDirectory)
 		}
 	}
 	catch (const fs::filesystem_error& e) {
-		logger.Log(e.what());
+		Log(e.what());
 	}
 }
 

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -4,6 +4,7 @@
 #include "FileSystemHelper.h"
 #include "GlobalDefines.h"
 #include "op2ext-Internal.h"
+#include "Log.h"
 #include "WindowsModule.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -98,7 +99,7 @@ OP2EXT_API void Log(const char* message)
 	// These optimizations are however extremely unlikely when making
 	// calls across a module boundary (such as to exported methods).
 
-	logger.Log(message, FindModuleName(_ReturnAddress()));
+	Log(message, FindModuleName(_ReturnAddress()));
 }
 
 
@@ -138,7 +139,7 @@ OP2EXT_API size_t GetLoadedModuleName(size_t moduleIndex, char* buffer, size_t b
 	}
 	catch (const std::exception& e) // Prevent throwing an error across DLL boundaries
 	{
-		logger.Log("op2ext threw an exception attempting to locate and pass the module name for module loaded at index " + 
+		Log("op2ext threw an exception attempting to locate and pass the module name for module loaded at index " +
 			std::to_string(moduleIndex) + ". Details: " + std::string(e.what()));
 	}
 

--- a/srcStatic/GlobalDefines.cpp
+++ b/srcStatic/GlobalDefines.cpp
@@ -1,6 +1,7 @@
 #include "GlobalDefines.h"
 #include "FileSystemHelper.h"
 #include "op2ext-Internal.h"
+#include "Log.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <sstream>
@@ -22,11 +23,11 @@ void DisableModalDialogs()
 
 void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, const std::string& errorMessage)
 {
-	// __FILE__ returns absolute filename. Strip the absolute path to reduce clutter in logger.
+	// __FILE__ returns absolute filename. Strip the absolute path to reduce clutter in log output
 	sourceFilename = fs::path(sourceFilename).filename().string();
 
 	const std::string formattedMessage = sourceFilename + ", Line: " + std::to_string(lineInSourceCode) + ": " + errorMessage;
-	logger.Log(formattedMessage);
+	Log(formattedMessage);
 	if (!modalDialogsDisabled) {
 		MessageBoxA(nullptr, formattedMessage.c_str(), "Outpost 2 Error", MB_ICONERROR);
 	}

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -1,9 +1,8 @@
 #include "Log.h"
-#include "LoggerFile.h"
 #include "op2ext-Internal.h"
 
 
 void Log(const std::string& message, const std::string& moduleName) {
 	// Delegate to internal logger
-	logger.Log(message, moduleName);
+	logger->Log(message, moduleName);
 }

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -1,0 +1,9 @@
+#include "Log.h"
+#include "Logger.h"
+#include "op2ext-Internal.h"
+
+
+void Log(const std::string& message, const std::string& moduleName) {
+	// Delegate to internal logger
+	logger.Log(message, moduleName);
+}

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -1,5 +1,5 @@
 #include "Log.h"
-#include "Logger.h"
+#include "LoggerFile.h"
 #include "op2ext-Internal.h"
 
 

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -2,6 +2,13 @@
 #include "op2ext-Internal.h"
 
 
+// Set logging output destination
+// Caller owns the logger and is responsible for cleanup when logger is no longer required
+// Use `SetLogger(nullptr);` to unset a logger
+void SetLogger(Logger* newLogger) {
+	logger = newLogger;
+}
+
 void Log(const std::string& message, const std::string& moduleName) {
 	// Delegate to internal logger
 	logger->Log(message, moduleName);

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -10,6 +10,9 @@ void SetLogger(Logger* newLogger) {
 }
 
 void Log(const std::string& message, const std::string& moduleName) {
-	// Delegate to internal logger
-	logger->Log(message, moduleName);
+	// Make sure a logger has been set first
+	if (logger) {
+		// Delegate to internal logger
+		logger->Log(message, moduleName);
+	}
 }

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -2,6 +2,16 @@
 #include "op2ext-Internal.h"
 
 
+// Use anonymous namespace to keep globals private
+// Prevents other files from gaining access with a sneaky extern declaration
+namespace {
+  // Static (constant and zero) initialization happens before dynamic initialization
+  // Such values are well defined if accessed by a global object constructor before Main/DllMain starts
+  // This pointer is safely set to null before other globals are initialized
+  Logger* logger = nullptr;
+}
+
+
 // Set logging output destination
 // Caller owns the logger and is responsible for cleanup when logger is no longer required
 // Use `SetLogger(nullptr);` to unset a logger

--- a/srcStatic/Log.h
+++ b/srcStatic/Log.h
@@ -1,0 +1,4 @@
+#include <string>
+
+
+void Log(const std::string& message, const std::string& moduleName = "op2ext.dll");

--- a/srcStatic/Log.h
+++ b/srcStatic/Log.h
@@ -1,4 +1,8 @@
 #include <string>
 
 
+class Logger;
+
+
+void SetLogger(Logger* logger);
 void Log(const std::string& message, const std::string& moduleName = "op2ext.dll");

--- a/srcStatic/Logger.h
+++ b/srcStatic/Logger.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+
+class Logger
+{
+public:
+	virtual void Log(const std::string& message, const std::string& moduleName = "op2ext.dll") = 0;
+};

--- a/srcStatic/LoggerFile.cpp
+++ b/srcStatic/LoggerFile.cpp
@@ -19,11 +19,6 @@ LoggerFile::LoggerFile() :
 	}
 }
 
-LoggerFile::~LoggerFile()
-{
-	logFile.close();
-}
-
 void LoggerFile::Log(const std::string& message, const std::string& moduleName)
 {
 	logFile << GetSystemDateTime() << " [" << moduleName << "] " << message << std::endl;

--- a/srcStatic/LoggerFile.cpp
+++ b/srcStatic/LoggerFile.cpp
@@ -1,4 +1,4 @@
-#include "Logger.h"
+#include "LoggerFile.h"
 
 #include "FileSystemHelper.h"
 #include "GlobalDefines.h"
@@ -11,7 +11,7 @@
 std::string GetSystemDateTime();
 
 
-Logger::Logger() :
+LoggerFile::LoggerFile() :
 	logFile(GetGameDirectory() + "\\Outpost2Log.txt", std::ios::app | std::ios::out | std::ios::binary)
 {
 	if (!logFile.is_open()) {
@@ -19,12 +19,12 @@ Logger::Logger() :
 	}
 }
 
-Logger::~Logger()
+LoggerFile::~LoggerFile()
 {
 	logFile.close();
 }
 
-void Logger::Log(const std::string& message, const std::string& moduleName)
+void LoggerFile::Log(const std::string& message, const std::string& moduleName)
 {
 	logFile << GetSystemDateTime() << " [" << moduleName << "] " << message << std::endl;
 }

--- a/srcStatic/LoggerFile.h
+++ b/srcStatic/LoggerFile.h
@@ -9,7 +9,6 @@ class LoggerFile : public Logger
 {
 public:
 	LoggerFile();
-	~LoggerFile();
 
 	void Log(const std::string& message, const std::string& moduleName = "op2ext.dll") override;
 

--- a/srcStatic/LoggerFile.h
+++ b/srcStatic/LoggerFile.h
@@ -3,11 +3,11 @@
 #include <fstream>
 #include <string>
 
-class Logger
+class LoggerFile
 {
 public:
-	Logger();
-	~Logger();
+	LoggerFile();
+	~LoggerFile();
 
 	void Log(const std::string& message, const std::string& moduleName = "op2ext.dll");
 

--- a/srcStatic/LoggerFile.h
+++ b/srcStatic/LoggerFile.h
@@ -2,14 +2,16 @@
 
 #include <fstream>
 #include <string>
+#include "Logger.h"
 
-class LoggerFile
+
+class LoggerFile : public Logger
 {
 public:
 	LoggerFile();
 	~LoggerFile();
 
-	void Log(const std::string& message, const std::string& moduleName = "op2ext.dll");
+	void Log(const std::string& message, const std::string& moduleName = "op2ext.dll") override;
 
 private:
 	std::ofstream logFile;

--- a/srcStatic/op2ext-Internal.cpp
+++ b/srcStatic/op2ext-Internal.cpp
@@ -3,10 +3,12 @@
 #include "ConsoleArgumentParser.h"
 #include "OP2Memory.h"
 #include "GlobalDefines.h"
+#include "LoggerFile.h"
 
 
 bool modulesRunning = false;
-LoggerFile logger;
+LoggerFile loggerFile;
+Logger* logger = &loggerFile;
 VolList volList;
 std::string moduleDirectory; // Must be defined + initialized before consoleModLoader
 ConsoleModuleLoader consoleModLoader(FindModuleDirectory());

--- a/srcStatic/op2ext-Internal.cpp
+++ b/srcStatic/op2ext-Internal.cpp
@@ -7,8 +7,6 @@
 
 
 bool modulesRunning = false;
-LoggerFile loggerFile;
-Logger* logger = &loggerFile;
 VolList volList;
 std::string moduleDirectory; // Must be defined + initialized before consoleModLoader
 ConsoleModuleLoader consoleModLoader(FindModuleDirectory());

--- a/srcStatic/op2ext-Internal.cpp
+++ b/srcStatic/op2ext-Internal.cpp
@@ -6,7 +6,7 @@
 
 
 bool modulesRunning = false;
-Logger logger;
+LoggerFile logger;
 VolList volList;
 std::string moduleDirectory; // Must be defined + initialized before consoleModLoader
 ConsoleModuleLoader consoleModLoader(FindModuleDirectory());

--- a/srcStatic/op2ext-Internal.h
+++ b/srcStatic/op2ext-Internal.h
@@ -12,7 +12,6 @@
 // Attempting further initialization commands will cause errors.
 extern bool modulesRunning;
 
-extern Logger* logger;
 extern VolList volList;
 extern ConsoleModuleLoader consoleModLoader;
 extern ModuleLoader moduleLoader;

--- a/srcStatic/op2ext-Internal.h
+++ b/srcStatic/op2ext-Internal.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "LoggerFile.h"
+#include "Logger.h"
 #include "ConsoleModuleLoader.h"
 #include "ModuleLoader.h"
 #include "VolList.h"
@@ -12,7 +12,7 @@
 // Attempting further initialization commands will cause errors.
 extern bool modulesRunning;
 
-extern LoggerFile logger;
+extern Logger* logger;
 extern VolList volList;
 extern ConsoleModuleLoader consoleModLoader;
 extern ModuleLoader moduleLoader;

--- a/srcStatic/op2ext-Internal.h
+++ b/srcStatic/op2ext-Internal.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-#include "Logger.h"
+#include "LoggerFile.h"
 #include "ConsoleModuleLoader.h"
 #include "ModuleLoader.h"
 #include "VolList.h"
@@ -12,7 +12,7 @@
 // Attempting further initialization commands will cause errors.
 extern bool modulesRunning;
 
-extern Logger logger;
+extern LoggerFile logger;
 extern VolList volList;
 extern ConsoleModuleLoader consoleModLoader;
 extern ModuleLoader moduleLoader;

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -138,7 +138,7 @@
     <ClCompile Include="GameModules\IpDropDown.cpp" />
     <ClCompile Include="ConsoleModuleLoader.cpp" />
     <ClCompile Include="Log.cpp" />
-    <ClCompile Include="Logger.cpp" />
+    <ClCompile Include="LoggerFile.cpp" />
     <ClCompile Include="op2ext-Internal.cpp" />
     <ClCompile Include="OP2Memory.cpp" />
     <ClCompile Include="StringConversion.cpp" />
@@ -157,7 +157,7 @@
     <ClInclude Include="GameModules\IpDropDown.h" />
     <ClInclude Include="ConsoleModuleLoader.h" />
     <ClInclude Include="Log.h" />
-    <ClInclude Include="Logger.h" />
+    <ClInclude Include="LoggerFile.h" />
     <ClInclude Include="op2ext-Internal.h" />
     <ClInclude Include="OP2Memory.h" />
     <ClInclude Include="StringConversion.h" />

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -137,6 +137,7 @@
     <ClCompile Include="ModuleLoader.cpp" />
     <ClCompile Include="GameModules\IpDropDown.cpp" />
     <ClCompile Include="ConsoleModuleLoader.cpp" />
+    <ClCompile Include="Log.cpp" />
     <ClCompile Include="Logger.cpp" />
     <ClCompile Include="op2ext-Internal.cpp" />
     <ClCompile Include="OP2Memory.cpp" />
@@ -155,6 +156,7 @@
     <ClInclude Include="ModuleLoader.h" />
     <ClInclude Include="GameModules\IpDropDown.h" />
     <ClInclude Include="ConsoleModuleLoader.h" />
+    <ClInclude Include="Log.h" />
     <ClInclude Include="Logger.h" />
     <ClInclude Include="op2ext-Internal.h" />
     <ClInclude Include="OP2Memory.h" />

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -157,6 +157,7 @@
     <ClInclude Include="GameModules\IpDropDown.h" />
     <ClInclude Include="ConsoleModuleLoader.h" />
     <ClInclude Include="Log.h" />
+    <ClInclude Include="Logger.h" />
     <ClInclude Include="LoggerFile.h" />
     <ClInclude Include="op2ext-Internal.h" />
     <ClInclude Include="OP2Memory.h" />

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -31,6 +31,7 @@
     <ClInclude Include="ModuleLoader.h" />
     <ClInclude Include="ConsoleModuleLoader.h" />
     <ClInclude Include="Log.h"/>
+    <ClInclude Include="Logger.h"/>
     <ClInclude Include="LoggerFile.h"/>
     <ClInclude Include="op2ext-Internal.h" />
     <ClInclude Include="OP2Memory.h" />

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -8,7 +8,7 @@
     <ClCompile Include="ModuleLoader.cpp" />
     <ClCompile Include="ConsoleModuleLoader.cpp" />
     <ClCompile Include="Log.cpp"/>
-    <ClCompile Include="Logger.cpp" />
+    <ClCompile Include="LoggerFile.cpp"/>
     <ClCompile Include="op2ext-Internal.cpp" />
     <ClCompile Include="OP2Memory.cpp" />
     <ClCompile Include="StringConversion.cpp" />
@@ -31,7 +31,7 @@
     <ClInclude Include="ModuleLoader.h" />
     <ClInclude Include="ConsoleModuleLoader.h" />
     <ClInclude Include="Log.h"/>
-    <ClInclude Include="Logger.h" />
+    <ClInclude Include="LoggerFile.h"/>
     <ClInclude Include="op2ext-Internal.h" />
     <ClInclude Include="OP2Memory.h" />
     <ClInclude Include="StringConversion.h" />

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -7,6 +7,7 @@
     <ClCompile Include="GlobalDefines.cpp" />
     <ClCompile Include="ModuleLoader.cpp" />
     <ClCompile Include="ConsoleModuleLoader.cpp" />
+    <ClCompile Include="Log.cpp"/>
     <ClCompile Include="Logger.cpp" />
     <ClCompile Include="op2ext-Internal.cpp" />
     <ClCompile Include="OP2Memory.cpp" />
@@ -29,6 +30,7 @@
     <ClInclude Include="GlobalDefines.h" />
     <ClInclude Include="ModuleLoader.h" />
     <ClInclude Include="ConsoleModuleLoader.h" />
+    <ClInclude Include="Log.h"/>
     <ClInclude Include="Logger.h" />
     <ClInclude Include="op2ext-Internal.h" />
     <ClInclude Include="OP2Memory.h" />

--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -1,17 +1,13 @@
 #include "Log.h"
 #include "Logger.h"
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 
 TEST(Log, UnsetLoggerIsSafe) {
 	EXPECT_NO_THROW(SetLogger(nullptr));
 	EXPECT_NO_THROW(Log("This goes nowhere"));
 }
-
-
-#if __has_include(<gmock/gmock.h>)
-
-#include <gmock/gmock.h>
 
 class MockLogger : public Logger {
 public:
@@ -29,4 +25,3 @@ TEST(Log, ActiveLoggerReceivesMessages) {
 	EXPECT_NO_THROW(SetLogger(nullptr));
 }
 
-#endif

--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -1,7 +1,6 @@
 #include "Log.h"
 #include "Logger.h"
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
 
 TEST(Log, UnsetLoggerIsSafe) {
@@ -9,6 +8,10 @@ TEST(Log, UnsetLoggerIsSafe) {
 	EXPECT_NO_THROW(Log("This goes nowhere"));
 }
 
+
+#if __has_include(<gmock/gmock.h>)
+
+#include <gmock/gmock.h>
 
 class MockLogger : public Logger {
 public:
@@ -25,3 +28,5 @@ TEST(Log, ActiveLoggerReceivesMessages) {
 	EXPECT_NO_THROW(Log(message));
 	EXPECT_NO_THROW(SetLogger(nullptr));
 }
+
+#endif

--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -1,9 +1,27 @@
 #include "Log.h"
 #include "Logger.h"
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 
 TEST(Log, UnsetLoggerIsSafe) {
 	EXPECT_NO_THROW(SetLogger(nullptr));
 	EXPECT_NO_THROW(Log("This goes nowhere"));
+}
+
+
+class MockLogger : public Logger {
+public:
+	MOCK_METHOD2(Log, void(const std::string& message, const std::string& moduleName));
+};
+
+TEST(Log, ActiveLoggerReceivesMessages) {
+	const auto message = std::string("Logger should receive this");
+
+	MockLogger logger;
+	EXPECT_CALL(logger, Log(message, "op2ext.dll"));
+
+	EXPECT_NO_THROW(SetLogger(&logger));
+	EXPECT_NO_THROW(Log(message));
+	EXPECT_NO_THROW(SetLogger(nullptr));
 }

--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -1,0 +1,9 @@
+#include "Log.h"
+#include "Logger.h"
+#include <gtest/gtest.h>
+
+
+TEST(Log, UnsetLoggerIsSafe) {
+	EXPECT_NO_THROW(SetLogger(nullptr));
+	EXPECT_NO_THROW(Log("This goes nowhere"));
+}

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -8,6 +8,8 @@ const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
 
 TEST(LoggerFile, LogFileExists)
 {
+	LoggerFile logger;
+
 	std::error_code errorCode;
 	ASSERT_TRUE(fs::exists(logPath, errorCode));
 }

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -9,9 +9,7 @@ const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
 TEST(LoggerFile, LogFileExists)
 {
 	LoggerFile logger;
-
-	std::error_code errorCode;
-	ASSERT_TRUE(fs::exists(logPath, errorCode));
+	ASSERT_TRUE(fs::exists(logPath));
 }
 
 TEST(LoggerFile, MessageLogged)

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -8,6 +8,7 @@ const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
 
 TEST(LoggerFile, LogFileExists)
 {
+	// Creating a logger should open or create a log file
 	LoggerFile logger;
 	ASSERT_TRUE(fs::exists(logPath));
 }

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -1,4 +1,4 @@
-#include "Logger.h"
+#include "LoggerFile.h"
 #include "FileSystemHelper.h"
 #include <gtest/gtest.h>
 #include <system_error>
@@ -6,15 +6,15 @@
 
 const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
 
-TEST(Logger, LogFileExists)
+TEST(LoggerFile, LogFileExists)
 {
 	std::error_code errorCode;
 	ASSERT_TRUE(fs::exists(logPath, errorCode));
 }
 
-TEST(Logger, MessageLogged)
+TEST(LoggerFile, MessageLogged)
 {
-	Logger logger;
+	LoggerFile logger;
 
 	const uintmax_t preFileSize = fs::file_size(logPath);
 	EXPECT_NO_THROW(logger.Log("Test Log Message"));

--- a/test/packages.config
+++ b/test/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="gmock" version="1.8.1" targetFramework="native" />
   <package id="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" version="1.8.1" targetFramework="native" />
 </packages>

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -29,7 +29,7 @@
     <ClCompile Include="ConsolueModuleLoader.test.cpp" />
     <ClCompile Include="FileSystemHelper.test.cpp" />
     <ClCompile Include="ModuleLoader.test.cpp" />
-    <ClCompile Include="Logger.test.cpp" />
+    <ClCompile Include="LoggerFile.test.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="op2ext.test.cpp" />
     <ClCompile Include="OP2Memory.test.cpp" />

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -28,6 +28,7 @@
     <ClCompile Include="ConsoleArgumentParser.test.cpp" />
     <ClCompile Include="ConsolueModuleLoader.test.cpp" />
     <ClCompile Include="FileSystemHelper.test.cpp" />
+    <ClCompile Include="Log.test.cpp" />
     <ClCompile Include="ModuleLoader.test.cpp" />
     <ClCompile Include="LoggerFile.test.cpp" />
     <ClCompile Include="Main.cpp" />

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -48,6 +48,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets" Condition="Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" />
+    <Import Project="..\packages\gmock.1.8.1\build\native\gmock.targets" Condition="Exists('..\packages\gmock.1.8.1\build\native\gmock.targets')" />
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
@@ -85,5 +86,6 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.1.8.1\build\native\Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets'))" />
+    <Error Condition="!Exists('..\packages\gmock.1.8.1\build\native\gmock.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\gmock.1.8.1\build\native\gmock.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
Here is some refactoring to help support Issue #131.

I was starting on some Google Mock tests, but it seems there's a version mismatch between the documentation I was reading, and what I have installed. I think I'll punt on that part for now.

The changes introduce a new global `Log(message, module = "op2ext")` function. This function then delegates to the `Logger`. Access to the former global variable is now much more restricted. The `Logger` was split into an interface and a `LoggerFile` implementation.

The new global `LoggerFile` object has been moved to DllMain.cpp, rather than being in the static library. This is a much more sensible place for it, and interferes less with testing. The static library should just be providing methods that can be called, not dictating global objects that must exist. I plan to create an issue about moving the other globals.

I carefully checked the code and C++ reference documents on initialization order to make sure the logging code didn't violate anything. Hopefully I got it all right.

I didn't bother with thread local variables for this update. We can look into that in a future update.
