### PR TITLE
Move `StringSplit` method

### DIFF
--- a/srcStatic/GlobalDefines.cpp
+++ b/srcStatic/GlobalDefines.cpp
@@ -3,8 +3,6 @@
 #include "op2ext-Internal.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <sstream>
-#include <cstddef>
 
 bool modalDialogsDisabled = false;
 
@@ -30,45 +28,4 @@ void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, const s
 	if (!modalDialogsDisabled) {
 		MessageBoxA(nullptr, formattedMessage.c_str(), "Outpost 2 Error", MB_ICONERROR);
 	}
-}
-
-std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption)
-{
-	std::vector<std::string> strings;
-
-	std::istringstream stringStream(stringToSplit);
-	std::string currentToken;
-
-	while (std::getline(stringStream, currentToken, delimiter)) {
-		currentToken = TrimString(currentToken, trimOption);
-		strings.push_back(currentToken);
-	}
-
-	return strings;
-}
-
-// Trims both leading and trailing whitespace. The 'whitespace' character may be custom defined.
-std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace)
-{
-	if (trimOption == TrimOption::None) {
-		return std::string();
-	}
-
-	std::size_t stringBegin = 0;
-	if (trimOption == TrimOption::Leading || trimOption == TrimOption::Both) {
-		stringBegin = stringToTrim.find_first_not_of(whitespace);
-	}
-
-	if (stringBegin == std::string::npos) {
-		return std::string(); // no content provided
-	}
-
-	auto stringEnd = stringToTrim.length();
-	if (trimOption == TrimOption::Trailing || trimOption == TrimOption::Both) {
-		stringEnd = stringToTrim.find_last_not_of(whitespace);
-	}
-
-	const auto range = stringEnd - stringBegin + 1;
-
-	return stringToTrim.substr(stringBegin, range);
 }

--- a/srcStatic/GlobalDefines.h
+++ b/srcStatic/GlobalDefines.h
@@ -1,23 +1,11 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 // Outputs a debug string. Output is not logged by the logger.
 void OutputDebug(std::string message);
-
-// Defines how leading and trailing characters of a string are trimmed.
-enum class TrimOption
-{
-	Trailing,
-	Leading,
-	Both,
-	None
-};
 
 // DisableModalDialogs will stop PostErrorMessage from posting modal dialogs. For use in test environment.
 void DisableModalDialogs();
 // Logs an error message with the logger and then posts it to user in a modal dialog box.
 void PostErrorMessage(std::string sourceFilename, long lineInSourceCode, const std::string& errorMessage);
-std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption);
-std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace = " \t");

--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -3,6 +3,7 @@
 #include "GameModules/IniModule.h"
 #include "StringConversion.h"
 #include "FileSystemHelper.h"
+#include "GlobalDefines.h"
 #include <stdexcept>
 
 

--- a/srcStatic/ModuleLoader.h
+++ b/srcStatic/ModuleLoader.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "GameModule.h"
-#include "GlobalDefines.h"
 #include <string>
 #include <vector>
 #include <memory>

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -1,4 +1,5 @@
 #include "StringConversion.h"
+#include <sstream>
 #include <algorithm>
 
 std::string ConvertLpctstrToString(LPCSTR str)
@@ -59,4 +60,46 @@ std::string ToLower(std::string x) {
 	std::transform(x.begin(), x.end(), x.begin(), ::tolower);
 
 	return x;
+}
+
+
+std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption)
+{
+	std::vector<std::string> strings;
+
+	std::istringstream stringStream(stringToSplit);
+	std::string currentToken;
+
+	while (std::getline(stringStream, currentToken, delimiter)) {
+		currentToken = TrimString(currentToken, trimOption);
+		strings.push_back(currentToken);
+	}
+
+	return strings;
+}
+
+// Trims both leading and trailing whitespace. The 'whitespace' character may be custom defined.
+std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace)
+{
+	if (trimOption == TrimOption::None) {
+		return std::string();
+	}
+
+	std::size_t stringBegin = 0;
+	if (trimOption == TrimOption::Leading || trimOption == TrimOption::Both) {
+		stringBegin = stringToTrim.find_first_not_of(whitespace);
+	}
+
+	if (stringBegin == std::string::npos) {
+		return std::string(); // no content provided
+	}
+
+	auto stringEnd = stringToTrim.length();
+	if (trimOption == TrimOption::Trailing || trimOption == TrimOption::Both) {
+		stringEnd = stringToTrim.find_last_not_of(whitespace);
+	}
+
+	const auto range = stringEnd - stringBegin + 1;
+
+	return stringToTrim.substr(stringBegin, range);
 }

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -4,6 +4,7 @@
 
 #include <windows.h>
 #include <string>
+#include <vector>
 #include <cstddef>
 
 // Converts a LPWSTR to std::string
@@ -21,3 +22,16 @@ std::string& ToLowerInPlace(std::string& x);
 
 // Returns a new string where all characters have been converted to lower case
 std::string ToLower(std::string x);
+
+
+// Defines how leading and trailing characters of a string are trimmed.
+enum class TrimOption
+{
+	Trailing,
+	Leading,
+	Both,
+	None
+};
+
+std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption);
+std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace = " \t");

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -27,10 +27,10 @@ std::string ToLower(std::string x);
 // Defines how leading and trailing characters of a string are trimmed.
 enum class TrimOption
 {
+	None,
 	Trailing,
 	Leading,
 	Both,
-	None
 };
 
 std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption = TrimOption::Both);

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -33,5 +33,5 @@ enum class TrimOption
 	None
 };
 
-std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption);
+std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption = TrimOption::Both);
 std::string TrimString(const std::string& stringToTrim, TrimOption trimOption = TrimOption::Both, const std::string& whitespace = " \t");

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -34,4 +34,4 @@ enum class TrimOption
 };
 
 std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption);
-std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace = " \t");
+std::string TrimString(const std::string& stringToTrim, TrimOption trimOption = TrimOption::Both, const std::string& whitespace = " \t");

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -20,6 +20,46 @@ TEST(StringConversion, ToLowerInPlace)
 	EXPECT_EQ("", str);
 }
 
+TEST(StringConversion, SplitString)
+{
+	// Empty string
+	EXPECT_EQ(std::vector<std::string>{}, SplitString("", ','));
+
+	// Single entry
+	EXPECT_EQ(std::vector<std::string>{"A"}, SplitString("A", ','));
+
+	// Empty multi entry
+	// EXPECT_EQ((std::vector<std::string>{"", ""}), SplitString(",", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", ""}), SplitString(",,", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", "", ""}), SplitString(",,,", ','));
+
+	// Multi entry
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A,B,C", ','));
+
+	// Multi entry with spaces
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A, B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A ,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A , B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A, B, C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A ,B ,C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A , B , C", ','));
+
+	// Embedded spaces
+	EXPECT_EQ((std::vector<std::string>{"A A"}), SplitString("A A", ','));
+	EXPECT_EQ((std::vector<std::string>{"A A", "B  B", "C\tC"}), SplitString("A A,B  B,C\tC", ','));
+
+	// Mixed spaces with embedded spaces
+	EXPECT_EQ((std::vector<std::string>{"A A", "B  B", "C\tC"}), SplitString("A A , B  B , C\tC", ','));
+
+	// Space separated
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A B C", ' '));
+	// EXPECT_EQ((std::vector<std::string>{"", "A", "B", "C", ""}), SplitString(" A B C ", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A\tB\tC"}), SplitString("A\tB\tC", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A \tB\t C", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("\tA\t \tB\t \tC\t", ' '));
+}
+
 TEST(StringConversion, TrimString)
 {
 	// Empty string

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -19,3 +19,45 @@ TEST(StringConversion, ToLowerInPlace)
 	EXPECT_EQ("", ToLowerInPlace(str));
 	EXPECT_EQ("", str);
 }
+
+TEST(StringConversion, TrimString)
+{
+	// Empty string
+	EXPECT_EQ("", TrimString(""));
+
+	// Only whitespace
+	EXPECT_EQ("", TrimString(" "));
+	EXPECT_EQ("", TrimString("\t"));
+	EXPECT_EQ("", TrimString("\t "));
+	EXPECT_EQ("", TrimString(" \t"));
+	EXPECT_EQ("", TrimString("\t\t"));
+
+	// Only no whitespace
+	EXPECT_EQ("A", TrimString("A"));
+	EXPECT_EQ("AA", TrimString("AA"));
+	EXPECT_EQ("ABC", TrimString("ABC"));
+
+	// Leading whitespace
+	EXPECT_EQ("A", TrimString(" A"));
+	EXPECT_EQ("A", TrimString("\tA"));
+
+	// Trailing whitespace
+	EXPECT_EQ("A", TrimString("A "));
+	EXPECT_EQ("A", TrimString("A\t"));
+
+	// Leading and trailing whitespace
+	EXPECT_EQ("A", TrimString(" A "));
+	EXPECT_EQ("A", TrimString("\tA\t"));
+	EXPECT_EQ("A", TrimString("  A  "));
+	EXPECT_EQ("A", TrimString(" \tA\t "));
+	EXPECT_EQ("A", TrimString("\t A \t"));
+	EXPECT_EQ("A", TrimString("\t\tA\t\t"));
+
+	// Embedded whitespace
+	EXPECT_EQ("A A", TrimString("A A"));
+	EXPECT_EQ("A\tA", TrimString("A\tA"));
+	EXPECT_EQ("A  A", TrimString("A  A"));
+	EXPECT_EQ("A \tA", TrimString("A \tA"));
+	EXPECT_EQ("A\t A", TrimString("A\t A"));
+	EXPECT_EQ("A\t\tA", TrimString("A\t\tA"));
+}


### PR DESCRIPTION
The `SplitString` and `TrimString` methods are better declared among the other string functions.

I added some unit tests. It looks like we may have a few corner cases that may not behave as expected. I left the offending checks commented out. I don't think we need to fix them at this time. They don't seem to be particularly relevant.

I also noted we may want to avoid designs where functions take an `enum` parameter, and that parameter is likely to be a fixed constant at the call site. I'll discuss it further in an issue, along with a few alternatives. Any bug fixes (assuming we agree they are bugs) can be rolled into that.
