### PR TITLE
Simplify `GetLastErrorString()` parameters

### DIFF
--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -94,7 +94,7 @@ void ConsoleModuleLoader::LoadModuleDll()
 	}
 	else {
 		const std::string errorMessage("Unable to load console module's dll from " + dllName +
-			". " + GetLastErrorString("LoadLibrary"));
+			". LoadLibrary " + GetLastErrorString());
 
 		PostErrorMessage(__FILE__, __LINE__, errorMessage);
 	}

--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -30,7 +30,7 @@ HINSTANCE IniModule::LoadModuleDll()
 
 	if (dllHandle == 0) {
 		throw std::runtime_error("Unable to load DLL " + dllName + " from ini module section " +
-			Name() + ". " + GetLastErrorString("LoadLibrary"));
+			Name() + ". LoadLibrary " + GetLastErrorString());
 	}
 
 	return dllHandle;

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -3,7 +3,7 @@
 #include "LocalResource.h"
 #include <windows.h>
 
-std::string GetLastErrorString(std::string functionName)
+std::string GetLastErrorString()
 {
 	LocalResource<LPTSTR> lpMsgBuf;
 	DWORD lastErrorCode = GetLastError();
@@ -21,7 +21,7 @@ std::string GetLastErrorString(std::string functionName)
 	);
 
 	auto errorCodeMessage = ConvertLpctstrToString(lpMsgBuf);
-	auto errorMessage = functionName + " failed with error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
+	auto errorMessage = "Error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
 
 	return errorMessage;
 }

--- a/srcStatic/WindowsErrorCode.h
+++ b/srcStatic/WindowsErrorCode.h
@@ -2,4 +2,4 @@
 #include <string>
 
 // Retrieve the system error message for the last-error code
-std::string GetLastErrorString(std::string functionName);
+std::string GetLastErrorString();


### PR DESCRIPTION
This closes #129.

Not sure if you want to adjust the error strings at all.
