### PR TITLE
Unicode fixes

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -15,7 +15,7 @@
 void LocateVolFiles(const std::string& relativeDirectory = "");
 
 // Declaration for patch to LoadLibrary, where it loads OP2Shell.dll
-HINSTANCE __stdcall LoadLibraryNew(LPCTSTR lpLibFileName);
+HINSTANCE __stdcall NewLoadLibraryA(LPCTSTR lpLibFileName);
 
 // Brett208 12Dec17: Following code allows adding multiple language support to Outpost 2 menus.
 // Code is incomplete.
@@ -33,7 +33,7 @@ public:
 };
 
 DWORD* loadLibraryDataAddr = (DWORD*)0x00486E0A;
-DWORD loadLibraryNewAddr = (DWORD)LoadLibraryNew;
+DWORD loadLibraryNewAddr = (DWORD)NewLoadLibraryA;
 
 // Warning: globals requiring dynamic initialization
 // Dynamic initialization order between translation units is unsequenced
@@ -144,10 +144,10 @@ void LocateVolFiles(const std::string& relativeDirectory)
 	}
 }
 
-HINSTANCE __stdcall LoadLibraryNew(LPCTSTR lpLibFileName)
+HINSTANCE __stdcall NewLoadLibraryA(LPCSTR lpLibFileName)
 {
 	// First try to load it
-	HINSTANCE result = LoadLibrary(lpLibFileName);
+	HINSTANCE result = LoadLibraryA(lpLibFileName);
 
 	if (result) // if good, then setup the language data and call the mod
 	{

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -15,7 +15,7 @@
 void LocateVolFiles(const std::string& relativeDirectory = "");
 
 // Declaration for patch to LoadLibrary, where it loads OP2Shell.dll
-HINSTANCE __stdcall NewLoadLibraryA(LPCTSTR lpLibFileName);
+HINSTANCE __stdcall NewLoadLibraryA(LPCSTR lpLibFileName);
 
 // Brett208 12Dec17: Following code allows adding multiple language support to Outpost 2 menus.
 // Code is incomplete.

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -83,7 +83,7 @@ void ConsoleModuleLoader::LoadModuleDll()
 		return; // Some console modules do not contain dlls
 	}
 
-	modDllHandle = LoadLibrary(dllName.c_str());
+	modDllHandle = LoadLibraryA(dllName.c_str());
 
 	if (modDllHandle) {
 		// Call module's mod_init function

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -42,7 +42,7 @@ std::string GetPrivateProfileStdString(const std::string& sectionName, const std
 		//GetPrivateProfileString's return value is the number of characters copied to the buffer,
 		// not including the terminating null character.
 		// A full buffer could be nSize - 2 if either lpAppName or lpKeyName are NULL AND the supplied buffer is too small
-		returnSize = GetPrivateProfileString(sectionName.c_str(), key.c_str(), "", &profileString[0], currentBufferSize, filename.c_str());
+		returnSize = GetPrivateProfileStringA(sectionName.c_str(), key.c_str(), "", &profileString[0], currentBufferSize, filename.c_str());
 
 		if (returnSize + 2 < currentBufferSize) {
 			break;

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -11,7 +11,7 @@ std::string GetPrivateProfileStdString(const std::string& sectionName, const std
 std::string GetGameDirectory()
 {
 	char moduleFilename[MAX_PATH];
-	GetModuleFileName(nullptr, moduleFilename, MAX_PATH);
+	GetModuleFileNameA(nullptr, moduleFilename, MAX_PATH);
 
 	return fs::path(moduleFilename).remove_filename().string();
 }

--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -26,7 +26,7 @@ HINSTANCE IniModule::LoadModuleDll()
 	std::string dllName = GetOutpost2IniSetting(Name(), "Dll");
 
 	// Try to load a DLL with the given name (possibly "")
-	HINSTANCE dllHandle = LoadLibrary(dllName.c_str());
+	HINSTANCE dllHandle = LoadLibraryA(dllName.c_str());
 
 	if (dllHandle == 0) {
 		throw std::runtime_error("Unable to load DLL " + dllName + " from ini module section " +

--- a/srcStatic/GameModules/IpDropDown.cpp
+++ b/srcStatic/GameModules/IpDropDown.cpp
@@ -107,9 +107,9 @@ void WriteAddressesToIniFile()
 	// Write IP addresses to .ini file
 	std::string iniPath = GetOutpost2IniPath();
 
-	WritePrivateProfileString("IPHistory", nullptr, nullptr, iniPath.c_str());
+	WritePrivateProfileStringA("IPHistory", nullptr, nullptr, iniPath.c_str());
 
 	for (int i = 0; i < numIpStrings; i++) {
-		WritePrivateProfileString("IPHistory", std::to_string(i).c_str(), ipStrings[i], iniPath.c_str());
+		WritePrivateProfileStringA("IPHistory", std::to_string(i).c_str(), ipStrings[i], iniPath.c_str());
 	}
 }

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -31,7 +31,7 @@ void SetLoadOffset()
 		return;
 	}
 
-	void* op2ModuleBase = GetModuleHandle("Outpost2.exe");
+	void* op2ModuleBase = GetModuleHandle(TEXT("Outpost2.exe"));
 
 	if (op2ModuleBase == 0) {
 		PostErrorMessage(__FILE__, __LINE__, "Could not find Outpost2.exe module base address.");

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -5,17 +5,17 @@
 
 std::string GetLastErrorString()
 {
-	LocalResource<LPTSTR> lpMsgBuf;
+	LocalResource<LPSTR> lpMsgBuf;
 	DWORD lastErrorCode = GetLastError();
 
-	FormatMessage(
+	FormatMessageA(
 		FORMAT_MESSAGE_ALLOCATE_BUFFER |
 		FORMAT_MESSAGE_FROM_SYSTEM |
 		FORMAT_MESSAGE_IGNORE_INSERTS,
 		NULL,
 		lastErrorCode,
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-		reinterpret_cast<LPTSTR>(&lpMsgBuf),
+		reinterpret_cast<LPSTR>(&lpMsgBuf),
 		0,
 		NULL
 	);

--- a/srcStatic/WindowsModule.cpp
+++ b/srcStatic/WindowsModule.cpp
@@ -1,4 +1,11 @@
 #include "WindowsModule.h"
+// Unicode builds of this file are unsupported
+// We must use the non "W" variant of Module32First, Module32Next, MODULEENTRY32
+// The API (public function signature) must not depend on types affected by unicode settings
+// Callers should no see any unicode affect types, nor care about the unicode setting of this file
+// Force a non-unicode build of this translation unit
+#undef UNICODE
+#undef _UNICODE
 #include <windows.h>
 #include <tlhelp32.h> // CreateToolhelp32Snapshot, Module32First, Module32Next
 


### PR DESCRIPTION
This resolves some of the earlier sloppiness regarding the `UNICODE` setting from Issue #149. It doesn't fix everything, but it should resolve most problems.

Mostly, I explicitly resolved in favour of narrow strings, since much of the code base has such an assumption built in. We can revisit this later if we ever decide to put effort into relaxing those assumptions.
