### PR TITLE
Split `TrimString`

### DIFF
--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -47,7 +47,7 @@ bool ModuleLoader::IsBuiltInModuleRequested(const std::string& moduleName)
 std::vector<std::string> ModuleLoader::GetModuleNames(const std::string& moduleType)
 {
 	std::string sectionNames = GetOutpost2IniSetting("Game", moduleType);
-	std::vector<std::string> sectionNamesSplit = SplitString(sectionNames, ',', TrimOption::Both);
+	std::vector<std::string> sectionNamesSplit = SplitAndTrim(sectionNames, ',');
 
 	return sectionNamesSplit;
 }

--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -46,10 +46,10 @@ bool ModuleLoader::IsBuiltInModuleRequested(const std::string& moduleName)
 
 std::vector<std::string> ModuleLoader::GetModuleNames(const std::string& moduleType)
 {
-	auto sectionNames = GetOutpost2IniSetting("Game", moduleType);
-	auto sectionNamesSplit = SplitAndTrim(sectionNames, ',');
+	auto sectionNamesString = GetOutpost2IniSetting("Game", moduleType);
+	auto sectionNames = SplitAndTrim(sectionNamesString, ',');
 
-	return sectionNamesSplit;
+	return sectionNames;
 }
 
 std::string ModuleLoader::GetModuleName(std::size_t index)

--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -46,8 +46,8 @@ bool ModuleLoader::IsBuiltInModuleRequested(const std::string& moduleName)
 
 std::vector<std::string> ModuleLoader::GetModuleNames(const std::string& moduleType)
 {
-	std::string sectionNames = GetOutpost2IniSetting("Game", moduleType);
-	std::vector<std::string> sectionNamesSplit = SplitAndTrim(sectionNames, ',');
+	auto sectionNames = GetOutpost2IniSetting("Game", moduleType);
+	auto sectionNamesSplit = SplitAndTrim(sectionNames, ',');
 
 	return sectionNamesSplit;
 }

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -105,6 +105,21 @@ std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, c
 }
 
 
+std::vector<std::string> Split(std::string stringToSplit, char delimiter)
+{
+	std::vector<std::string> strings;
+
+	std::istringstream stringStream(stringToSplit);
+	std::string currentToken;
+
+	while (std::getline(stringStream, currentToken, delimiter)) {
+		strings.push_back(currentToken);
+	}
+
+	return strings;
+}
+
+
 // Trim whitespace from both ends of string, returning copy of substring
 std::string Trim(const std::string& stringToTrim, const std::string& whitespace)
 {

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -63,21 +63,6 @@ std::string ToLower(std::string x) {
 }
 
 
-std::vector<std::string> Split(std::string stringToSplit, char delimiter)
-{
-	std::vector<std::string> strings;
-
-	std::istringstream stringStream(stringToSplit);
-	std::string currentToken;
-
-	while (std::getline(stringStream, currentToken, delimiter)) {
-		strings.push_back(currentToken);
-	}
-
-	return strings;
-}
-
-
 // Trim whitespace from both ends of string, returning copy of substring
 std::string Trim(const std::string& stringToTrim, const std::string& whitespace)
 {
@@ -111,4 +96,19 @@ std::string TrimBack(const std::string& stringToTrim, const std::string& whitesp
 	auto stringEnd = stringToTrim.find_last_not_of(whitespace);
 
 	return stringToTrim.substr(0, stringEnd + 1);
+}
+
+
+std::vector<std::string> Split(std::string stringToSplit, char delimiter)
+{
+	std::vector<std::string> strings;
+
+	std::istringstream stringStream(stringToSplit);
+	std::string currentToken;
+
+	while (std::getline(stringStream, currentToken, delimiter)) {
+		strings.push_back(currentToken);
+	}
+
+	return strings;
 }

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -103,3 +103,39 @@ std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, c
 
 	return stringToTrim.substr(stringBegin, range);
 }
+
+
+// Trim whitespace from both ends of string, returning copy of substring
+std::string Trim(const std::string& stringToTrim, const std::string& whitespace)
+{
+	auto stringBegin = stringToTrim.find_first_not_of(whitespace);
+
+	if (stringBegin == std::string::npos) {
+		return std::string(); // no content provided
+	}
+
+	auto stringEnd = stringToTrim.find_last_not_of(whitespace);
+
+	const auto range = stringEnd - stringBegin + 1;
+	return stringToTrim.substr(stringBegin, range);
+}
+
+// Trim whitespace from front of string, returning copy of substring
+std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace)
+{
+	auto stringBegin = stringToTrim.find_first_not_of(whitespace);
+
+	if (stringBegin == std::string::npos) {
+		return std::string(); // no content provided
+	}
+
+	return stringToTrim.substr(stringBegin, std::string::npos);
+}
+
+// Trim whitespace from back of string, returning copy of substring
+std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace)
+{
+	auto stringEnd = stringToTrim.find_last_not_of(whitespace);
+
+	return stringToTrim.substr(0, stringEnd + 1);
+}

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -63,33 +63,6 @@ std::string ToLower(std::string x) {
 }
 
 
-// Trims both leading and trailing whitespace. The 'whitespace' character may be custom defined.
-std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace)
-{
-	if (trimOption == TrimOption::None) {
-		return std::string();
-	}
-
-	std::size_t stringBegin = 0;
-	if (trimOption == TrimOption::Leading || trimOption == TrimOption::Both) {
-		stringBegin = stringToTrim.find_first_not_of(whitespace);
-	}
-
-	if (stringBegin == std::string::npos) {
-		return std::string(); // no content provided
-	}
-
-	auto stringEnd = stringToTrim.length();
-	if (trimOption == TrimOption::Trailing || trimOption == TrimOption::Both) {
-		stringEnd = stringToTrim.find_last_not_of(whitespace);
-	}
-
-	const auto range = stringEnd - stringBegin + 1;
-
-	return stringToTrim.substr(stringBegin, range);
-}
-
-
 std::vector<std::string> Split(std::string stringToSplit, char delimiter)
 {
 	std::vector<std::string> strings;

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -63,21 +63,6 @@ std::string ToLower(std::string x) {
 }
 
 
-std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption)
-{
-	std::vector<std::string> strings;
-
-	std::istringstream stringStream(stringToSplit);
-	std::string currentToken;
-
-	while (std::getline(stringStream, currentToken, delimiter)) {
-		currentToken = TrimString(currentToken, trimOption);
-		strings.push_back(currentToken);
-	}
-
-	return strings;
-}
-
 // Trims both leading and trailing whitespace. The 'whitespace' character may be custom defined.
 std::string TrimString(const std::string& stringToTrim, TrimOption trimOption, const std::string& whitespace)
 {

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -35,7 +35,6 @@ enum class TrimOption
 	Both,
 };
 
-std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption = TrimOption::Both);
 std::string TrimString(const std::string& stringToTrim, TrimOption trimOption = TrimOption::Both, const std::string& whitespace = " \t");
 
 std::vector<std::string> Split(std::string stringToSplit, char delimiter);

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -26,17 +26,6 @@ std::string& ToLowerInPlace(std::string& x);
 std::string ToLower(std::string x);
 
 
-// Defines how leading and trailing characters of a string are trimmed.
-enum class TrimOption
-{
-	None,
-	Trailing,
-	Leading,
-	Both,
-};
-
-std::string TrimString(const std::string& stringToTrim, TrimOption trimOption = TrimOption::Both, const std::string& whitespace = " \t");
-
 std::vector<std::string> Split(std::string stringToSplit, char delimiter);
 
 std::string Trim(const std::string& stringToTrim, const std::string& whitespace = " \t");

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -43,3 +43,12 @@ std::vector<std::string> Split(std::string stringToSplit, char delimiter);
 std::string Trim(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = " \t");
+
+template <typename std::string(TrimFunction)(const std::string&, const std::string&) = Trim>
+std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, const std::string& whitespace = " \t") {
+	auto items = Split(stringToSplit, delimiter);
+	for (auto& item : items) {
+		item = TrimFunction(item, whitespace);
+	}
+	return items;
+}

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -26,11 +26,11 @@ std::string& ToLowerInPlace(std::string& x);
 std::string ToLower(std::string x);
 
 
-std::vector<std::string> Split(std::string stringToSplit, char delimiter);
-
 std::string Trim(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = " \t");
+
+std::vector<std::string> Split(std::string stringToSplit, char delimiter);
 
 template <typename std::string(TrimFunction)(const std::string&, const std::string&) = Trim>
 std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, const std::string& whitespace = " \t") {

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -38,6 +38,8 @@ enum class TrimOption
 std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption = TrimOption::Both);
 std::string TrimString(const std::string& stringToTrim, TrimOption trimOption = TrimOption::Both, const std::string& whitespace = " \t");
 
+std::vector<std::string> Split(std::string stringToSplit, char delimiter);
+
 std::string Trim(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = " \t");

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -37,3 +37,7 @@ enum class TrimOption
 
 std::vector<std::string> SplitString(std::string stringToSplit, char delimiter, TrimOption trimOption = TrimOption::Both);
 std::string TrimString(const std::string& stringToTrim, TrimOption trimOption = TrimOption::Both, const std::string& whitespace = " \t");
+
+std::string Trim(const std::string& stringToTrim, const std::string& whitespace = " \t");
+std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = " \t");
+std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = " \t");

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -38,46 +38,6 @@ TEST(StringConversion, ToLowerInPlace)
 	EXPECT_EQ("", str);
 }
 
-TEST(StringConversion, SplitString)
-{
-	// Empty string
-	EXPECT_EQ(std::vector<std::string>{}, SplitString("", ','));
-
-	// Single entry
-	EXPECT_EQ(std::vector<std::string>{"A"}, SplitString("A", ','));
-
-	// Empty multi entry
-	// EXPECT_EQ((std::vector<std::string>{"", ""}), SplitString(",", ','));
-	// EXPECT_EQ((std::vector<std::string>{"", "", ""}), SplitString(",,", ','));
-	// EXPECT_EQ((std::vector<std::string>{"", "", "", ""}), SplitString(",,,", ','));
-
-	// Multi entry
-	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A,B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A,B,C", ','));
-
-	// Multi entry with spaces
-	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A, B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A ,B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitString("A , B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A, B, C", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A ,B ,C", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A , B , C", ','));
-
-	// Embedded spaces
-	EXPECT_EQ((std::vector<std::string>{"A A"}), SplitString("A A", ','));
-	EXPECT_EQ((std::vector<std::string>{"A A", "B  B", "C\tC"}), SplitString("A A,B  B,C\tC", ','));
-
-	// Mixed spaces with embedded spaces
-	EXPECT_EQ((std::vector<std::string>{"A A", "B  B", "C\tC"}), SplitString("A A , B  B , C\tC", ','));
-
-	// Space separated
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A B C", ' '));
-	// EXPECT_EQ((std::vector<std::string>{"", "A", "B", "C", ""}), SplitString(" A B C ", ' '));
-	EXPECT_EQ((std::vector<std::string>{"A\tB\tC"}), SplitString("A\tB\tC", ' '));
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("A \tB\t C", ' '));
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("\tA\t \tB\t \tC\t", ' '));
-}
-
 TEST(StringConversion, Split)
 {
 	// Empty string

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -316,3 +316,14 @@ TEST(StringConversion, SplitAndTrim)
 	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("A \tB\t C", ' '));
 	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("\tA\t \tB\t \tC\t", ' '));
 }
+
+TEST(StringConversion, SplitAndTrimTrimFront)
+{
+	// Multi entry with spaces (trim only front spaces)
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitAndTrim<TrimFront>("A, B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B"}), SplitAndTrim<TrimFront>("A ,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B"}), SplitAndTrim<TrimFront>("A , B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim<TrimFront>("A, B, C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B ", "C"}), SplitAndTrim<TrimFront>("A ,B ,C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B ", "C"}), SplitAndTrim<TrimFront>("A , B , C", ','));
+}

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -78,6 +78,37 @@ TEST(StringConversion, SplitString)
 	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitString("\tA\t \tB\t \tC\t", ' '));
 }
 
+TEST(StringConversion, Split)
+{
+	// Empty string
+	EXPECT_EQ(std::vector<std::string>{}, Split("", ','));
+
+	// Single entry
+	EXPECT_EQ(std::vector<std::string>{"A"}, Split("A", ','));
+
+	// Empty multi entry
+	// EXPECT_EQ((std::vector<std::string>{"", ""}), Split(",", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", ""}), Split(",,", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", "", ""}), Split(",,,", ','));
+
+	// Multi entry
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), Split("A,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), Split("A,B,C", ','));
+
+	// Multi entry with spaces (no trimming)
+	EXPECT_EQ((std::vector<std::string>{"A", " B"}), Split("A, B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B"}), Split("A ,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", " B"}), Split("A , B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", " B", " C"}), Split("A, B, C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B ", "C"}), Split("A ,B ,C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", " B ", " C"}), Split("A , B , C", ','));
+
+	// Space separated
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), Split("A B C", ' '));
+	// EXPECT_EQ((std::vector<std::string>{"", "A", "B", "C", ""}), Split(" A B C ", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A\tB\tC"}), Split("A\tB\tC", ' '));
+}
+
 TEST(StringConversion, TrimString)
 {
 	// Empty string

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -69,48 +69,6 @@ TEST(StringConversion, Split)
 	EXPECT_EQ((std::vector<std::string>{"A\tB\tC"}), Split("A\tB\tC", ' '));
 }
 
-TEST(StringConversion, TrimString)
-{
-	// Empty string
-	EXPECT_EQ("", TrimString(""));
-
-	// Only whitespace
-	EXPECT_EQ("", TrimString(" "));
-	EXPECT_EQ("", TrimString("\t"));
-	EXPECT_EQ("", TrimString("\t "));
-	EXPECT_EQ("", TrimString(" \t"));
-	EXPECT_EQ("", TrimString("\t\t"));
-
-	// Only no whitespace
-	EXPECT_EQ("A", TrimString("A"));
-	EXPECT_EQ("AA", TrimString("AA"));
-	EXPECT_EQ("ABC", TrimString("ABC"));
-
-	// Leading whitespace
-	EXPECT_EQ("A", TrimString(" A"));
-	EXPECT_EQ("A", TrimString("\tA"));
-
-	// Trailing whitespace
-	EXPECT_EQ("A", TrimString("A "));
-	EXPECT_EQ("A", TrimString("A\t"));
-
-	// Leading and trailing whitespace
-	EXPECT_EQ("A", TrimString(" A "));
-	EXPECT_EQ("A", TrimString("\tA\t"));
-	EXPECT_EQ("A", TrimString("  A  "));
-	EXPECT_EQ("A", TrimString(" \tA\t "));
-	EXPECT_EQ("A", TrimString("\t A \t"));
-	EXPECT_EQ("A", TrimString("\t\tA\t\t"));
-
-	// Embedded whitespace
-	EXPECT_EQ("A A", TrimString("A A"));
-	EXPECT_EQ("A\tA", TrimString("A\tA"));
-	EXPECT_EQ("A  A", TrimString("A  A"));
-	EXPECT_EQ("A \tA", TrimString("A \tA"));
-	EXPECT_EQ("A\t A", TrimString("A\t A"));
-	EXPECT_EQ("A\t\tA", TrimString("A\t\tA"));
-}
-
 TEST(StringConversion, Trim)
 {
 	// Empty string

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -276,3 +276,43 @@ TEST(StringConversion, TrimBack)
 	EXPECT_EQ("A\t A", TrimBack("A\t A"));
 	EXPECT_EQ("A\t\tA", TrimBack("A\t\tA"));
 }
+
+TEST(StringConversion, SplitAndTrim)
+{
+	// Empty string
+	EXPECT_EQ(std::vector<std::string>{}, SplitAndTrim("", ','));
+
+	// Single entry
+	EXPECT_EQ(std::vector<std::string>{"A"}, SplitAndTrim("A", ','));
+
+	// Empty multi entry
+	// EXPECT_EQ((std::vector<std::string>{"", ""}), SplitAndTrim(",", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", ""}), SplitAndTrim(",,", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", "", ""}), SplitAndTrim(",,,", ','));
+
+	// Multi entry
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitAndTrim("A,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("A,B,C", ','));
+
+	// Multi entry with spaces
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitAndTrim("A, B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitAndTrim("A ,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), SplitAndTrim("A , B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("A, B, C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("A ,B ,C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("A , B , C", ','));
+
+	// Embedded spaces
+	EXPECT_EQ((std::vector<std::string>{"A A"}), SplitAndTrim("A A", ','));
+	EXPECT_EQ((std::vector<std::string>{"A A", "B  B", "C\tC"}), SplitAndTrim("A A,B  B,C\tC", ','));
+
+	// Mixed spaces with embedded spaces
+	EXPECT_EQ((std::vector<std::string>{"A A", "B  B", "C\tC"}), SplitAndTrim("A A , B  B , C\tC", ','));
+
+	// Space separated
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("A B C", ' '));
+	// EXPECT_EQ((std::vector<std::string>{"", "A", "B", "C", ""}), SplitAndTrim(" A B C ", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A\tB\tC"}), SplitAndTrim("A\tB\tC", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("A \tB\t C", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), SplitAndTrim("\tA\t \tB\t \tC\t", ' '));
+}

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -38,37 +38,6 @@ TEST(StringConversion, ToLowerInPlace)
 	EXPECT_EQ("", str);
 }
 
-TEST(StringConversion, Split)
-{
-	// Empty string
-	EXPECT_EQ(std::vector<std::string>{}, Split("", ','));
-
-	// Single entry
-	EXPECT_EQ(std::vector<std::string>{"A"}, Split("A", ','));
-
-	// Empty multi entry
-	// EXPECT_EQ((std::vector<std::string>{"", ""}), Split(",", ','));
-	// EXPECT_EQ((std::vector<std::string>{"", "", ""}), Split(",,", ','));
-	// EXPECT_EQ((std::vector<std::string>{"", "", "", ""}), Split(",,,", ','));
-
-	// Multi entry
-	EXPECT_EQ((std::vector<std::string>{"A", "B"}), Split("A,B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), Split("A,B,C", ','));
-
-	// Multi entry with spaces (no trimming)
-	EXPECT_EQ((std::vector<std::string>{"A", " B"}), Split("A, B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A ", "B"}), Split("A ,B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A ", " B"}), Split("A , B", ','));
-	EXPECT_EQ((std::vector<std::string>{"A", " B", " C"}), Split("A, B, C", ','));
-	EXPECT_EQ((std::vector<std::string>{"A ", "B ", "C"}), Split("A ,B ,C", ','));
-	EXPECT_EQ((std::vector<std::string>{"A ", " B ", " C"}), Split("A , B , C", ','));
-
-	// Space separated
-	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), Split("A B C", ' '));
-	// EXPECT_EQ((std::vector<std::string>{"", "A", "B", "C", ""}), Split(" A B C ", ' '));
-	EXPECT_EQ((std::vector<std::string>{"A\tB\tC"}), Split("A\tB\tC", ' '));
-}
-
 TEST(StringConversion, Trim)
 {
 	// Empty string
@@ -193,6 +162,37 @@ TEST(StringConversion, TrimBack)
 	EXPECT_EQ("A \tA", TrimBack("A \tA"));
 	EXPECT_EQ("A\t A", TrimBack("A\t A"));
 	EXPECT_EQ("A\t\tA", TrimBack("A\t\tA"));
+}
+
+TEST(StringConversion, Split)
+{
+	// Empty string
+	EXPECT_EQ(std::vector<std::string>{}, Split("", ','));
+
+	// Single entry
+	EXPECT_EQ(std::vector<std::string>{"A"}, Split("A", ','));
+
+	// Empty multi entry
+	// EXPECT_EQ((std::vector<std::string>{"", ""}), Split(",", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", ""}), Split(",,", ','));
+	// EXPECT_EQ((std::vector<std::string>{"", "", "", ""}), Split(",,,", ','));
+
+	// Multi entry
+	EXPECT_EQ((std::vector<std::string>{"A", "B"}), Split("A,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), Split("A,B,C", ','));
+
+	// Multi entry with spaces (no trimming)
+	EXPECT_EQ((std::vector<std::string>{"A", " B"}), Split("A, B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B"}), Split("A ,B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", " B"}), Split("A , B", ','));
+	EXPECT_EQ((std::vector<std::string>{"A", " B", " C"}), Split("A, B, C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", "B ", "C"}), Split("A ,B ,C", ','));
+	EXPECT_EQ((std::vector<std::string>{"A ", " B ", " C"}), Split("A , B , C", ','));
+
+	// Space separated
+	EXPECT_EQ((std::vector<std::string>{"A", "B", "C"}), Split("A B C", ' '));
+	// EXPECT_EQ((std::vector<std::string>{"", "A", "B", "C", ""}), Split(" A B C ", ' '));
+	EXPECT_EQ((std::vector<std::string>{"A\tB\tC"}), Split("A\tB\tC", ' '));
 }
 
 TEST(StringConversion, SplitAndTrim)

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -119,3 +119,129 @@ TEST(StringConversion, TrimString)
 	EXPECT_EQ("A\t A", TrimString("A\t A"));
 	EXPECT_EQ("A\t\tA", TrimString("A\t\tA"));
 }
+
+TEST(StringConversion, Trim)
+{
+	// Empty string
+	EXPECT_EQ("", Trim(""));
+
+	// Only whitespace
+	EXPECT_EQ("", Trim(" "));
+	EXPECT_EQ("", Trim("\t"));
+	EXPECT_EQ("", Trim("\t "));
+	EXPECT_EQ("", Trim(" \t"));
+	EXPECT_EQ("", Trim("\t\t"));
+
+	// Only no whitespace
+	EXPECT_EQ("A", Trim("A"));
+	EXPECT_EQ("AA", Trim("AA"));
+	EXPECT_EQ("ABC", Trim("ABC"));
+
+	// Leading whitespace
+	EXPECT_EQ("A", Trim(" A"));
+	EXPECT_EQ("A", Trim("\tA"));
+
+	// Trailing whitespace
+	EXPECT_EQ("A", Trim("A "));
+	EXPECT_EQ("A", Trim("A\t"));
+
+	// Leading and trailing whitespace
+	EXPECT_EQ("A", Trim(" A "));
+	EXPECT_EQ("A", Trim("\tA\t"));
+	EXPECT_EQ("A", Trim("  A  "));
+	EXPECT_EQ("A", Trim(" \tA\t "));
+	EXPECT_EQ("A", Trim("\t A \t"));
+	EXPECT_EQ("A", Trim("\t\tA\t\t"));
+
+	// Embedded whitespace
+	EXPECT_EQ("A A", Trim("A A"));
+	EXPECT_EQ("A\tA", Trim("A\tA"));
+	EXPECT_EQ("A  A", Trim("A  A"));
+	EXPECT_EQ("A \tA", Trim("A \tA"));
+	EXPECT_EQ("A\t A", Trim("A\t A"));
+	EXPECT_EQ("A\t\tA", Trim("A\t\tA"));
+}
+
+TEST(StringConversion, TrimFront)
+{
+	// Empty string
+	EXPECT_EQ("", TrimFront(""));
+
+	// Only whitespace
+	EXPECT_EQ("", TrimFront(" "));
+	EXPECT_EQ("", TrimFront("\t"));
+	EXPECT_EQ("", TrimFront("\t "));
+	EXPECT_EQ("", TrimFront(" \t"));
+	EXPECT_EQ("", TrimFront("\t\t"));
+
+	// Only no whitespace
+	EXPECT_EQ("A", TrimFront("A"));
+	EXPECT_EQ("AA", TrimFront("AA"));
+	EXPECT_EQ("ABC", TrimFront("ABC"));
+
+	// Leading whitespace
+	EXPECT_EQ("A", TrimFront(" A"));
+	EXPECT_EQ("A", TrimFront("\tA"));
+
+	// Trailing whitespace
+	EXPECT_EQ("A ", TrimFront("A "));
+	EXPECT_EQ("A\t", TrimFront("A\t"));
+
+	// Leading and trailing whitespace
+	EXPECT_EQ("A ", TrimFront(" A "));
+	EXPECT_EQ("A\t", TrimFront("\tA\t"));
+	EXPECT_EQ("A  ", TrimFront("  A  "));
+	EXPECT_EQ("A\t ", TrimFront(" \tA\t "));
+	EXPECT_EQ("A \t", TrimFront("\t A \t"));
+	EXPECT_EQ("A\t\t", TrimFront("\t\tA\t\t"));
+
+	// Embedded whitespace
+	EXPECT_EQ("A A", TrimFront("A A"));
+	EXPECT_EQ("A\tA", TrimFront("A\tA"));
+	EXPECT_EQ("A  A", TrimFront("A  A"));
+	EXPECT_EQ("A \tA", TrimFront("A \tA"));
+	EXPECT_EQ("A\t A", TrimFront("A\t A"));
+	EXPECT_EQ("A\t\tA", TrimFront("A\t\tA"));
+}
+
+TEST(StringConversion, TrimBack)
+{
+	// Empty string
+	EXPECT_EQ("", TrimBack(""));
+
+	// Only whitespace
+	EXPECT_EQ("", TrimBack(" "));
+	EXPECT_EQ("", TrimBack("\t"));
+	EXPECT_EQ("", TrimBack("\t "));
+	EXPECT_EQ("", TrimBack(" \t"));
+	EXPECT_EQ("", TrimBack("\t\t"));
+
+	// Only no whitespace
+	EXPECT_EQ("A", TrimBack("A"));
+	EXPECT_EQ("AA", TrimBack("AA"));
+	EXPECT_EQ("ABC", TrimBack("ABC"));
+
+	// Leading whitespace
+	EXPECT_EQ(" A", TrimBack(" A"));
+	EXPECT_EQ("\tA", TrimBack("\tA"));
+
+	// Trailing whitespace
+	EXPECT_EQ("A", TrimBack("A "));
+	EXPECT_EQ("A", TrimBack("A\t"));
+
+	// Leading and trailing whitespace
+	EXPECT_EQ(" A", TrimBack(" A "));
+	EXPECT_EQ("\tA", TrimBack("\tA\t"));
+	EXPECT_EQ("  A", TrimBack("  A  "));
+	EXPECT_EQ(" \tA", TrimBack(" \tA\t "));
+	EXPECT_EQ("\t A", TrimBack("\t A \t"));
+	EXPECT_EQ("\t\tA", TrimBack("\t\tA\t\t"));
+
+	// Embedded whitespace
+	EXPECT_EQ("A A", TrimBack("A A"));
+	EXPECT_EQ("A\tA", TrimBack("A\tA"));
+	EXPECT_EQ("A  A", TrimBack("A  A"));
+	EXPECT_EQ("A \tA", TrimBack("A \tA"));
+	EXPECT_EQ("A\t A", TrimBack("A\t A"));
+	EXPECT_EQ("A\t\tA", TrimBack("A\t\tA"));
+}


### PR DESCRIPTION
This closes #145.

I ended up using a bit of a hybrid approach, using aspects from all 3 suggested styles.

It occurred to me the `ModuleLoader::GetModuleNames` method was untested. To avoid dumping new code with significant changes into that method, I choose to keep a `SplitAndTrim` method within the StringConversion library code. It delegates to the `Split` method and the `Trim` method, where the `Trim` method is actually a template parameter, with a default to trim both ends. All 3 types of methods can be called independently, and all have their own test code. That minimized changes needed for the calling code.
