### PR TITLE
Cleanup `nullptr` checks

### DIFF
--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -39,7 +39,7 @@ HINSTANCE IniModule::LoadModuleDll()
 void IniModule::Load()
 {
 	// Call the InitMod function if it exists
-	if (initializeModuleFunction != 0) {
+	if (initializeModuleFunction != nullptr) {
 		initializeModuleFunction(Name().c_str());
 	}
 }
@@ -48,7 +48,7 @@ bool IniModule::Unload()
 {
 	bool success = true;
 
-	if (destroyModuleFunction != 0) {
+	if (destroyModuleFunction != nullptr) {
 		success = destroyModuleFunction();
 	}
 

--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -28,7 +28,7 @@ HINSTANCE IniModule::LoadModuleDll()
 	// Try to load a DLL with the given name (possibly "")
 	HINSTANCE dllHandle = LoadLibraryA(dllName.c_str());
 
-	if (dllHandle == 0) {
+	if (dllHandle == NULL) {
 		throw std::runtime_error("Unable to load DLL " + dllName + " from ini module section " +
 			Name() + ". LoadLibrary " + GetLastErrorString());
 	}

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -33,7 +33,7 @@ void SetLoadOffset()
 
 	void* op2ModuleBase = GetModuleHandle(TEXT("Outpost2.exe"));
 
-	if (op2ModuleBase == 0) {
+	if (op2ModuleBase == nullptr) {
 		PostErrorMessage(__FILE__, __LINE__, "Could not find Outpost2.exe module base address.");
 	}
 

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -12,12 +12,12 @@ std::string GetLastErrorString()
 		FORMAT_MESSAGE_ALLOCATE_BUFFER |
 		FORMAT_MESSAGE_FROM_SYSTEM |
 		FORMAT_MESSAGE_IGNORE_INSERTS,
-		NULL,
+		nullptr,
 		lastErrorCode,
 		MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 		reinterpret_cast<LPSTR>(&lpMsgBuf),
 		0,
-		NULL
+		nullptr
 	);
 
 	auto errorCodeMessage = ConvertLpctstrToString(lpMsgBuf);


### PR DESCRIPTION
I temporarily set `-Wzero-as-null-pointer-constant` for the Linux build to scan for uses of the literal `0` with pointers. That led to the cleanup here. I skipped fixing one warning that is fixed in the other open PR #156.

I do not wish to enable this check fully at this time as the Google Test code contains many violations of the check. It generates way too much spam when the test projects are compiled with this flag.

I would be interested in setting just the core projects (op2extLib, op2extDll) to compile with the warning enabled. However, the current makefile design pulls in the core project settings when compiling the related test projects. I would have to enable some sort of bypass mechanism to set this warning for the core projects, but not for the associated test projects. That would be work for a different branch.
