### PR TITLE
Cleanup string wrapping

### DIFF
--- a/srcStatic/LocalResource.h
+++ b/srcStatic/LocalResource.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <type_traits>
 

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -23,6 +23,15 @@ std::string ConvertWideToNarrow(std::wstring_view inputWideString)
 	return converter.to_bytes(std::wstring(inputWideString));
 }
 
+std::wstring ConvertNarrowToWide(std::string_view inputNarrowString)
+{
+	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
+	// Create a UTF-8 <=> UTF-16 converter
+	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+	// Convert from narrow to wide
+	return converter.from_bytes(std::string(inputNarrowString));
+}
+
 std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize)
 {
 	// Precheck valid pointer and non-zero buffer size to avoid wrap around or null termination problems

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -2,6 +2,7 @@
 #include <sstream>
 #include <algorithm>
 
+
 std::string WrapRawString(LPCSTR str)
 {
 	return std::string(str);

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -14,22 +14,22 @@ std::wstring WrapRawString(const wchar_t* str)
 	return std::wstring(str);
 }
 
-std::string ConvertWideToNarrow(const std::wstring& inputWideString)
+std::string ConvertWideToNarrow(const std::wstring& inputString)
 {
 	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
 	// Create a UTF-8 <=> UTF-16 converter
 	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-	// Convert from wide to narrow
-	return converter.to_bytes(inputWideString);
+	// Convert string
+	return converter.to_bytes(inputString);
 }
 
-std::wstring ConvertNarrowToWide(const std::string& inputNarrowString)
+std::wstring ConvertNarrowToWide(const std::string& inputString)
 {
 	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
 	// Create a UTF-8 <=> UTF-16 converter
 	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-	// Convert from narrow to wide
-	return converter.from_bytes(inputNarrowString);
+	// Convert string
+	return converter.from_bytes(inputString);
 }
 
 std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize)

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -1,6 +1,6 @@
-#include "StringConversion.h"
 // Deprecation warning suppression must come before any standard library includes
 #define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+#include "StringConversion.h"
 #include <sstream>
 #include <algorithm>
 #include <locale>

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -1,6 +1,8 @@
 #include "StringConversion.h"
 #include <sstream>
 #include <algorithm>
+#include <locale>
+#include <codecvt>
 
 
 std::string WrapRawString(const char* str)
@@ -12,34 +14,13 @@ std::wstring WrapRawString(const wchar_t* str)
 	return std::wstring(str);
 }
 
-std::string ConvertWideToNarrow(std::wstring_view inputWideString, UINT codepage)
+std::string ConvertWideToNarrow(std::wstring_view inputWideString)
 {
-	constexpr DWORD dwFlags = 0;
-
-	// The WideCharToMultiByte function considers it an error to pass an input string of length 0
-	// Early exit if input string is empty
-	if (inputWideString.empty()) {
-		return std::string();
-	}
-
-	// First determine the required buffer size (but don't convert)
-	auto requiredBufferSize = WideCharToMultiByte(codepage, dwFlags, inputWideString.data(), inputWideString.size(), nullptr, 0, nullptr, nullptr);
-	if (requiredBufferSize == 0) {
-		throw std::runtime_error("Wide to narrow string conversion failure: Unable to determine output buffer size");
-	}
-
-	std::string outputString;
-	// Allocate space for converted string
-	outputString.resize(requiredBufferSize);
-	// Perform the actual conversion
-	auto convertedSize = WideCharToMultiByte(codepage, dwFlags, inputWideString.data(), inputWideString.size(), outputString.data(), outputString.size(), nullptr, nullptr);
-	if (convertedSize == 0) {
-		throw std::runtime_error("Wide to narrow string conversion failure: Unable to convert string");
-	}
-	// Clip output string to however many characters were actually converted
-	outputString.erase(convertedSize);
-
-	return outputString;
+	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
+	// Create a UTF-8 <=> UTF-16 converter
+	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+	// Convert from wide to narrow
+	return converter.to_bytes(std::wstring(inputWideString));
 }
 
 std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize)

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -14,22 +14,22 @@ std::wstring WrapRawString(const wchar_t* str)
 	return std::wstring(str);
 }
 
-std::string ConvertWideToNarrow(std::wstring_view inputWideString)
+std::string ConvertWideToNarrow(const std::wstring& inputWideString)
 {
 	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
 	// Create a UTF-8 <=> UTF-16 converter
 	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
 	// Convert from wide to narrow
-	return converter.to_bytes(std::wstring(inputWideString));
+	return converter.to_bytes(inputWideString);
 }
 
-std::wstring ConvertNarrowToWide(std::string_view inputNarrowString)
+std::wstring ConvertNarrowToWide(const std::string& inputNarrowString)
 {
 	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
 	// Create a UTF-8 <=> UTF-16 converter
 	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
 	// Convert from narrow to wide
-	return converter.from_bytes(std::string(inputNarrowString));
+	return converter.from_bytes(inputNarrowString);
 }
 
 std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize)

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -1,4 +1,6 @@
 #include "StringConversion.h"
+// Deprecation warning suppression must come before any standard library includes
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include <sstream>
 #include <algorithm>
 #include <locale>

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -2,11 +2,11 @@
 #include <sstream>
 #include <algorithm>
 
-std::string ConvertLpctstrToString(LPCSTR str)
+std::string WrapRawString(LPCSTR str)
 {
 	return std::string(str);
 }
-std::wstring ConvertLpctstrToString(LPCWSTR str)
+std::wstring WrapRawString(LPCWSTR str)
 {
 	return std::wstring(str);
 }

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -14,23 +14,23 @@ std::wstring WrapRawString(const wchar_t* str)
 	return std::wstring(str);
 }
 
+
+// Define the type of converter we want for UTF-8 <=> UTF-16 conversions
+// Wide strings might use `wchar_t` or `char16_t`, so specify the type we want
+using ConverterType = std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>>;
+
 std::string ConvertWideToNarrow(const std::wstring& inputString)
 {
-	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
-	// Create a UTF-8 <=> UTF-16 converter
-	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-	// Convert string
-	return converter.to_bytes(inputString);
+	// Create converter and convert string
+	return ConverterType().to_bytes(inputString);
 }
 
 std::wstring ConvertNarrowToWide(const std::string& inputString)
 {
-	// Wide strings might be `wchar_t` or `char16_t`, so specify the type we want
-	// Create a UTF-8 <=> UTF-16 converter
-	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-	// Convert string
-	return converter.from_bytes(inputString);
+	// Create converter and convert string
+	return ConverterType().from_bytes(inputString);
 }
+
 
 std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize)
 {

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -3,11 +3,11 @@
 #include <algorithm>
 
 
-std::string WrapRawString(LPCSTR str)
+std::string WrapRawString(const char* str)
 {
 	return std::string(str);
 }
-std::wstring WrapRawString(LPCWSTR str)
+std::wstring WrapRawString(const wchar_t* str)
 {
 	return std::wstring(str);
 }

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -11,8 +11,8 @@
 // This may also potentially be used if a type depends on a #define setting.
 // Win32 Example: The UNICODE setting controls TCHAR, which controls LPTSTR and LPCTSTR
 // Function overload selection then results in the wrapped type std::string or std::wstring
-std::string WrapRawString(LPCSTR str);
-std::wstring WrapRawString(LPCWSTR str);
+std::string WrapRawString(const char* str);
+std::wstring WrapRawString(const wchar_t* str);
 
 // Converts a wide string to a multibyte narrow string
 std::string ConvertWideToNarrow(std::wstring_view inputWideString, UINT codepage = CP_ACP);

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -14,8 +14,8 @@ std::string WrapRawString(const char* str);
 std::wstring WrapRawString(const wchar_t* str);
 
 // Convert between wide strings and multibyte narrow strings
-std::string ConvertWideToNarrow(std::wstring_view inputWideString);
-std::wstring ConvertNarrowToWide(std::string_view inputNarrowString);
+std::string ConvertWideToNarrow(const std::wstring& inputWideString);
+std::wstring ConvertNarrowToWide(const std::string& inputNarrowString);
 
 // Copies a std::string to a raw character buffer
 // This is used to interface with C code

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -1,5 +1,3 @@
-// Functions that convert into and out of c-style strings and std::strings
-
 #pragma once
 
 #include <windows.h>
@@ -8,14 +6,19 @@
 #include <cstddef>
 
 
-// Convert a LPCTSTR to std::string
-// At compile time LPCTSTR will convert to either LPCSTR or LPCWSTR based on the UNICODE setting
+// Wraps either a narrow or wide raw string into either a std::string or std::wstring
+// Decision is made at compile time, though can be deferred until template instantiation
+// This may also potentially be used if a type depends on a #define setting.
+// Win32 Example: The UNICODE setting controls TCHAR, which controls LPTSTR and LPCTSTR
+// Function overload selection then results in the wrapped type std::string or std::wstring
 std::string WrapRawString(LPCSTR str);
 std::wstring WrapRawString(LPCWSTR str);
 
-// Converts a LPWSTR to std::string
+// Converts a wide string to a multibyte narrow string
 std::string ConvertWideToNarrow(std::wstring_view inputWideString, UINT codepage = CP_ACP);
 
+// Copies a std::string to a raw character buffer
+// This is used to interface with C code
 // Returns 0 on success
 // Returns needed buffer size (including space for null terminator) if the destination buffer is too small
 std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize);
@@ -27,12 +30,18 @@ std::string& ToLowerInPlace(std::string& x);
 std::string ToLower(std::string x);
 
 
+// Trim whitespace from both ends or either end of a string
 std::string Trim(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = " \t");
 std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = " \t");
 
+// Split string on all instances of a delimiter charater and return result in a vector of strings
+// The delimiter character is not included in the resulting strings
 std::vector<std::string> Split(std::string stringToSplit, char delimiter);
 
+// Split string on all instances of a delimiter character, and trim resulting strings, returning results in a vector
+// The delimiter character is not included in the resulting strings
+// If the delimiter character is a whitespace character, it is first used for splitting purposes
 template <typename std::string(TrimFunction)(const std::string&, const std::string&) = Trim>
 std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, const std::string& whitespace = " \t") {
 	auto items = Split(stringToSplit, delimiter);

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -13,8 +13,9 @@
 std::string WrapRawString(const char* str);
 std::wstring WrapRawString(const wchar_t* str);
 
-// Converts a wide string to a multibyte narrow string
+// Convert between wide strings and multibyte narrow strings
 std::string ConvertWideToNarrow(std::wstring_view inputWideString);
+std::wstring ConvertNarrowToWide(std::string_view inputNarrowString);
 
 // Copies a std::string to a raw character buffer
 // This is used to interface with C code

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -8,13 +8,13 @@
 #include <cstddef>
 
 
-// Converts a LPWSTR to std::string
-std::string ConvertWideToNarrow(std::wstring_view inputWideString, UINT codepage = CP_ACP);
-
 // Convert a LPCTSTR to std::string
 // At compile time LPCTSTR will convert to either LPCSTR or LPCWSTR based on the UNICODE setting
 std::string WrapRawString(LPCSTR str);
 std::wstring WrapRawString(LPCWSTR str);
+
+// Converts a LPWSTR to std::string
+std::string ConvertWideToNarrow(std::wstring_view inputWideString, UINT codepage = CP_ACP);
 
 // Returns 0 on success
 // Returns needed buffer size (including space for null terminator) if the destination buffer is too small

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -15,7 +15,7 @@ std::string WrapRawString(const char* str);
 std::wstring WrapRawString(const wchar_t* str);
 
 // Converts a wide string to a multibyte narrow string
-std::string ConvertWideToNarrow(std::wstring_view inputWideString, UINT codepage = CP_ACP);
+std::string ConvertWideToNarrow(std::wstring_view inputWideString);
 
 // Copies a std::string to a raw character buffer
 // This is used to interface with C code

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <windows.h>
 #include <string>
 #include <vector>
 #include <cstddef>

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -13,8 +13,8 @@ std::string ConvertWideToNarrow(std::wstring_view inputWideString, UINT codepage
 
 // Convert a LPCTSTR to std::string
 // At compile time LPCTSTR will convert to either LPCSTR or LPCWSTR based on the UNICODE setting
-std::string ConvertLpctstrToString(LPCSTR str);
-std::wstring ConvertLpctstrToString(LPCWSTR str);
+std::string WrapRawString(LPCSTR str);
+std::wstring WrapRawString(LPCWSTR str);
 
 // Returns 0 on success
 // Returns needed buffer size (including space for null terminator) if the destination buffer is too small

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -20,7 +20,7 @@ std::string GetLastErrorString()
 		NULL
 	);
 
-	auto errorCodeMessage = WrapRawString(lpMsgBuf);
+	auto errorCodeMessage = std::string(lpMsgBuf);
 	auto errorMessage = "Error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
 
 	return errorMessage;

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -1,5 +1,4 @@
 #include "WindowsErrorCode.h"
-#include "StringConversion.h"
 #include "LocalResource.h"
 #include <windows.h>
 

--- a/srcStatic/WindowsErrorCode.cpp
+++ b/srcStatic/WindowsErrorCode.cpp
@@ -20,7 +20,7 @@ std::string GetLastErrorString()
 		NULL
 	);
 
-	auto errorCodeMessage = ConvertLpctstrToString(lpMsgBuf);
+	auto errorCodeMessage = WrapRawString(lpMsgBuf);
 	auto errorMessage = "Error " + std::to_string(lastErrorCode) + ": " + errorCodeMessage;
 
 	return errorMessage;

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -13,18 +13,18 @@ TEST(StringConversion, ConvertWideToNarrow)
 	EXPECT_EQ("Hello world", ConvertWideToNarrow(L"Hello world"));
 }
 
-TEST(StringConversion, ConvertLpctstrToStringNarrow)
+TEST(StringConversion, WrapRawStringNarrow)
 {
 	LPCSTR rawString = "test string";
-	auto result = ConvertLpctstrToString(rawString);
+	auto result = WrapRawString(rawString);
 	EXPECT_EQ(rawString, result);
 	EXPECT_TRUE((std::is_same<std::string, decltype(result)>::value));
 }
 
-TEST(StringConversion, ConvertLpctstrToStringWide)
+TEST(StringConversion, WrapRawStringWide)
 {
 	LPCWSTR rawString = L"test string";
-	auto result = ConvertLpctstrToString(rawString);
+	auto result = WrapRawString(rawString);
 	EXPECT_EQ(rawString, result);
 	EXPECT_TRUE((std::is_same<std::wstring, decltype(result)>::value));
 }

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -29,6 +29,15 @@ TEST(StringConversion, ConvertWideToNarrow)
 	EXPECT_EQ("Hello world", ConvertWideToNarrow(L"Hello world"));
 }
 
+TEST(StringConversion, ConvertNarrowToWide)
+{
+	// Convert empty string
+	EXPECT_EQ(L"", ConvertNarrowToWide(""));
+
+	// Convert non-empty string
+	EXPECT_EQ(L"Hello world", ConvertNarrowToWide("Hello world"));
+}
+
 TEST(StringConversion, ToLower)
 {
 	EXPECT_EQ("test", ToLower("TEST"));

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -6,7 +6,7 @@
 
 TEST(StringConversion, WrapRawStringNarrow)
 {
-	LPCSTR rawString = "test string";
+	const char* rawString = "test string";
 	auto result = WrapRawString(rawString);
 	EXPECT_EQ(rawString, result);
 	EXPECT_TRUE((std::is_same<std::string, decltype(result)>::value));
@@ -14,7 +14,7 @@ TEST(StringConversion, WrapRawStringNarrow)
 
 TEST(StringConversion, WrapRawStringWide)
 {
-	LPCWSTR rawString = L"test string";
+	const wchar_t* rawString = L"test string";
 	auto result = WrapRawString(rawString);
 	EXPECT_EQ(rawString, result);
 	EXPECT_TRUE((std::is_same<std::wstring, decltype(result)>::value));

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -4,15 +4,6 @@
 #include <type_traits>
 
 
-TEST(StringConversion, ConvertWideToNarrow)
-{
-	// Convert empty string
-	EXPECT_EQ("", ConvertWideToNarrow(L""));
-
-	// Convert non-empty string
-	EXPECT_EQ("Hello world", ConvertWideToNarrow(L"Hello world"));
-}
-
 TEST(StringConversion, WrapRawStringNarrow)
 {
 	LPCSTR rawString = "test string";
@@ -27,6 +18,15 @@ TEST(StringConversion, WrapRawStringWide)
 	auto result = WrapRawString(rawString);
 	EXPECT_EQ(rawString, result);
 	EXPECT_TRUE((std::is_same<std::wstring, decltype(result)>::value));
+}
+
+TEST(StringConversion, ConvertWideToNarrow)
+{
+	// Convert empty string
+	EXPECT_EQ("", ConvertWideToNarrow(L""));
+
+	// Convert non-empty string
+	EXPECT_EQ("Hello world", ConvertWideToNarrow(L"Hello world"));
 }
 
 TEST(StringConversion, ToLower)


### PR DESCRIPTION
This closes #148.

I experimented with the standard C++ library methods for converting between UTF-8 and UTF-16 strings. It went quite well, so I decided to go with that. The change also helped remove Windows specific types from the function signatures, which allowed for the removal of the `<windows.h>` dependence.
