### PR TITLE
Cleanup whitespace constant

### DIFF
--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -105,7 +105,7 @@ std::string TrimBack(const std::string& stringToTrim, std::string_view whitespac
 }
 
 
-std::vector<std::string> Split(std::string stringToSplit, char delimiter)
+std::vector<std::string> Split(const std::string& stringToSplit, char delimiter)
 {
 	std::vector<std::string> strings;
 

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -70,7 +70,7 @@ std::string ToLower(std::string x) {
 
 
 // Trim whitespace from both ends of string, returning copy of substring
-std::string Trim(const std::string& stringToTrim, const std::string& whitespace)
+std::string Trim(const std::string& stringToTrim, std::string_view whitespace)
 {
 	auto stringBegin = stringToTrim.find_first_not_of(whitespace);
 
@@ -85,7 +85,7 @@ std::string Trim(const std::string& stringToTrim, const std::string& whitespace)
 }
 
 // Trim whitespace from front of string, returning copy of substring
-std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace)
+std::string TrimFront(const std::string& stringToTrim, std::string_view whitespace)
 {
 	auto stringBegin = stringToTrim.find_first_not_of(whitespace);
 
@@ -97,7 +97,7 @@ std::string TrimFront(const std::string& stringToTrim, const std::string& whites
 }
 
 // Trim whitespace from back of string, returning copy of substring
-std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace)
+std::string TrimBack(const std::string& stringToTrim, std::string_view whitespace)
 {
 	auto stringEnd = stringToTrim.find_last_not_of(whitespace);
 

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -27,14 +27,16 @@ std::string& ToLowerInPlace(std::string& x);
 std::string ToLower(std::string x);
 
 
-std::string Trim(const std::string& stringToTrim, const std::string& whitespace = " \t");
-std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = " \t");
-std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = " \t");
+constexpr auto Whitespace = " \t";
+
+std::string Trim(const std::string& stringToTrim, const std::string& whitespace = Whitespace);
+std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = Whitespace);
+std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = Whitespace);
 
 std::vector<std::string> Split(std::string stringToSplit, char delimiter);
 
 template <typename std::string(TrimFunction)(const std::string&, const std::string&) = Trim>
-std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, const std::string& whitespace = " \t") {
+std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, const std::string& whitespace = Whitespace) {
 	auto items = Split(stringToSplit, delimiter);
 	for (auto& item : items) {
 		item = TrimFunction(item, whitespace);

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -33,7 +33,7 @@ std::string Trim(const std::string& stringToTrim, std::string_view whitespace = 
 std::string TrimFront(const std::string& stringToTrim, std::string_view whitespace = Whitespace);
 std::string TrimBack(const std::string& stringToTrim, std::string_view whitespace = Whitespace);
 
-std::vector<std::string> Split(std::string stringToSplit, char delimiter);
+std::vector<std::string> Split(const std::string& stringToSplit, char delimiter);
 
 template <typename std::string(TrimFunction)(const std::string&, std::string_view) = Trim>
 std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, std::string_view whitespace = Whitespace) {

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -27,16 +27,16 @@ std::string& ToLowerInPlace(std::string& x);
 std::string ToLower(std::string x);
 
 
-constexpr auto Whitespace = " \t";
+constexpr std::string_view Whitespace = " \t";
 
-std::string Trim(const std::string& stringToTrim, const std::string& whitespace = Whitespace);
-std::string TrimFront(const std::string& stringToTrim, const std::string& whitespace = Whitespace);
-std::string TrimBack(const std::string& stringToTrim, const std::string& whitespace = Whitespace);
+std::string Trim(const std::string& stringToTrim, std::string_view whitespace = Whitespace);
+std::string TrimFront(const std::string& stringToTrim, std::string_view whitespace = Whitespace);
+std::string TrimBack(const std::string& stringToTrim, std::string_view whitespace = Whitespace);
 
 std::vector<std::string> Split(std::string stringToSplit, char delimiter);
 
-template <typename std::string(TrimFunction)(const std::string&, const std::string&) = Trim>
-std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, const std::string& whitespace = Whitespace) {
+template <typename std::string(TrimFunction)(const std::string&, std::string_view) = Trim>
+std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter, std::string_view whitespace = Whitespace) {
 	auto items = Split(stringToSplit, delimiter);
 	for (auto& item : items) {
 		item = TrimFunction(item, whitespace);


### PR DESCRIPTION
Replaced whitespace literals with named constant. Used a `std::string_view` to prevent expensive temporary object construction at point of calls for defaulted parameter uses.
