### PR TITLE
Update Linux targets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,5 +8,5 @@ jobs:
       - checkout
       - run: git submodule update --init || true
       - run: make --keep-going
-      - run: make --keep-going test
+      - run: make --keep-going testLib
       - run: make --keep-going check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - run: WINEARCH=win32 winecfg
       - checkout
       - run: git submodule update --init || true
-      - run: make --keep-going op2extLib
-      - run: make --keep-going op2extDll
-      - run: make --keep-going testLib
-      - run: make --keep-going check-testLib
+      - run: make --keep-going --jobs=2 op2extLib
+      - run: make --keep-going --jobs=2 op2extDll
+      - run: make --keep-going --jobs=2 testLib
+      - run: make --keep-going --jobs=2 check-testLib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,4 +10,4 @@ jobs:
       - run: make --keep-going op2extLib
       - run: make --keep-going op2extDll
       - run: make --keep-going testLib
-      - run: make --keep-going check
+      - run: make --keep-going check-testLib

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ jobs:
       - run: WINEARCH=win32 winecfg
       - checkout
       - run: git submodule update --init || true
-      - run: make --keep-going
+      - run: make --keep-going op2extLib
+      - run: make --keep-going op2extDll
       - run: make --keep-going testLib
       - run: make --keep-going check

--- a/makefile
+++ b/makefile
@@ -21,7 +21,7 @@ all: op2extLib op2extDll
 $(eval $(call DefineCppProject,op2extLib,op2ext.lib,srcStatic/))
 $(eval $(call DefineCppProject,op2extDll,op2ext.dll,srcDLL/,op2extLib))
 $(eval $(call DefineCppProject,testModule,testModule.dll,TestModule/,op2extDll))
-$(eval $(call DefineUnitTestProject,test,test/,op2extLib))
+$(eval $(call DefineUnitTestProject,testLib,test/,op2extLib))
 
 
 # Docker and CircleCI commands


### PR DESCRIPTION
Linux only change.

Updates the makefile target name to build the unit test project for the static library. This is in preparation for adding a unit test project for the DLL.

Splits the build steps on CircleCI so output from each project and each test run will go in their own section. This should allow for easier and faster diagnosis of where a problem is coming from.

Enabled parallelism during the build. The newer makefile structure allows for very good parallelism. The CircleCI environment offers up to 2 CPUs, so we should make use of that. When CircleCI is not loaded, some of the build steps can take about half the time now. When CircleCI is more loaded, there may be no real difference in build time compared to before.

Related: Issue #19.
