### PR TITLE
Create `LogMessageTest` fixture

### DIFF
--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -1,5 +1,5 @@
 #include "Log.h"
-#include "Logger.h"
+#include "LogMessageTest.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
@@ -8,27 +8,6 @@ TEST(Log, UnsetLoggerIsSafe) {
 	EXPECT_NO_THROW(SetLogger(nullptr));
 	EXPECT_NO_THROW(Log("This goes nowhere"));
 }
-
-
-class LoggerMock : public Logger {
-public:
-	MOCK_METHOD2(Log, void(const std::string& message, const std::string& moduleName));
-};
-
-
-class LogMessageTest : public ::testing::Test {
-protected:
-	void SetUp() override {
-		// Install test logger
-		EXPECT_NO_THROW(SetLogger(&logger));
-	}
-	void TearDown() override {
-		// Remove test logger
-		EXPECT_NO_THROW(SetLogger(nullptr));
-	}
-
-	LoggerMock logger;
-};
 
 
 TEST_F(LogMessageTest, ActiveLoggerReceivesMessages) {

--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -10,7 +10,7 @@ TEST(Log, UnsetLoggerIsSafe) {
 }
 
 
-class MockLogger : public Logger {
+class LoggerMock : public Logger {
 public:
 	MOCK_METHOD2(Log, void(const std::string& message, const std::string& moduleName));
 };
@@ -27,7 +27,7 @@ protected:
 		EXPECT_NO_THROW(SetLogger(nullptr));
 	}
 
-	MockLogger logger;
+	LoggerMock logger;
 };
 
 

--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -9,19 +9,31 @@ TEST(Log, UnsetLoggerIsSafe) {
 	EXPECT_NO_THROW(Log("This goes nowhere"));
 }
 
+
 class MockLogger : public Logger {
 public:
 	MOCK_METHOD2(Log, void(const std::string& message, const std::string& moduleName));
 };
 
-TEST(Log, ActiveLoggerReceivesMessages) {
-	const auto message = std::string("Logger should receive this");
+
+class LogMessageTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		// Install test logger
+		EXPECT_NO_THROW(SetLogger(&logger));
+	}
+	void TearDown() override {
+		// Remove test logger
+		EXPECT_NO_THROW(SetLogger(nullptr));
+	}
 
 	MockLogger logger;
-	EXPECT_CALL(logger, Log(message, "op2ext.dll"));
+};
 
-	EXPECT_NO_THROW(SetLogger(&logger));
+
+TEST_F(LogMessageTest, ActiveLoggerReceivesMessages) {
+	const auto message = std::string("Logger should receive this");
+	EXPECT_CALL(logger, Log(message, "op2ext.dll"));
 	EXPECT_NO_THROW(Log(message));
-	EXPECT_NO_THROW(SetLogger(nullptr));
 }
 

--- a/test/LogMessageTest.cpp
+++ b/test/LogMessageTest.cpp
@@ -1,4 +1,5 @@
 #include "LogMessageTest.h"
+#include "Log.h"
 
 
 // For compile speed reasons these should be instantiated in their own implementation file
@@ -6,3 +7,15 @@
 // In particular, this is where gMock actually performs verification of expectations
 LoggerMock::LoggerMock() {}
 LoggerMock::~LoggerMock() {}
+
+
+
+void LogMessageTest::SetUp() {
+	// Install test logger
+	EXPECT_NO_THROW(SetLogger(&logger));
+}
+
+void LogMessageTest::TearDown() {
+	// Remove test logger
+	EXPECT_NO_THROW(SetLogger(nullptr));
+}

--- a/test/LogMessageTest.cpp
+++ b/test/LogMessageTest.cpp
@@ -1,0 +1,8 @@
+#include "LogMessageTest.h"
+
+
+// For compile speed reasons these should be instantiated in their own implementation file
+// They may look trivial, but construct and destruct all hidden gMock member objects
+// In particular, this is where gMock actually performs verification of expectations
+LoggerMock::LoggerMock() {}
+LoggerMock::~LoggerMock() {}

--- a/test/LogMessageTest.h
+++ b/test/LogMessageTest.h
@@ -6,6 +6,9 @@
 
 class LoggerMock : public Logger {
 public:
+	LoggerMock();
+	virtual ~LoggerMock();
+
 	MOCK_METHOD2(Log, void(const std::string& message, const std::string& moduleName));
 };
 

--- a/test/LogMessageTest.h
+++ b/test/LogMessageTest.h
@@ -1,0 +1,25 @@
+#include "Log.h"
+#include "Logger.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+class LoggerMock : public Logger {
+public:
+	MOCK_METHOD2(Log, void(const std::string& message, const std::string& moduleName));
+};
+
+
+class LogMessageTest : public ::testing::Test {
+protected:
+	void SetUp() override {
+		// Install test logger
+		EXPECT_NO_THROW(SetLogger(&logger));
+	}
+	void TearDown() override {
+		// Remove test logger
+		EXPECT_NO_THROW(SetLogger(nullptr));
+	}
+
+	LoggerMock logger;
+};

--- a/test/LogMessageTest.h
+++ b/test/LogMessageTest.h
@@ -1,4 +1,3 @@
-#include "Log.h"
 #include "Logger.h"
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -15,14 +14,8 @@ public:
 
 class LogMessageTest : public ::testing::Test {
 protected:
-	void SetUp() override {
-		// Install test logger
-		EXPECT_NO_THROW(SetLogger(&logger));
-	}
-	void TearDown() override {
-		// Remove test logger
-		EXPECT_NO_THROW(SetLogger(nullptr));
-	}
+	void SetUp() override;
+	void TearDown() override;
 
 	LoggerMock logger;
 };

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="Log.test.cpp" />
     <ClCompile Include="ModuleLoader.test.cpp" />
     <ClCompile Include="LoggerFile.test.cpp" />
+    <ClCompile Include="LogMessageTest.cpp" />
     <ClCompile Include="Main.cpp" />
     <ClCompile Include="op2ext.test.cpp" />
     <ClCompile Include="OP2Memory.test.cpp" />


### PR DESCRIPTION
This contains some support work for Issue #107. Addressed is extracting some of the test code into a reusable `LogMessageTest` fixture. Some attention was paid to compile speed optimization, relevant to Mock objects.
