### PR TITLE
Test code cleanup

### DIFF
--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -26,7 +26,7 @@ TEST(ConsoleModuleLoader, NoModuleLoaded)
 
 TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 {
-	const auto moduleName("NoDllTest");
+	const std::string moduleName("NoDllTest");
 	ConsoleModuleLoader consoleModLoader(moduleName);
 
 	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -1,10 +1,10 @@
 #include "LoggerFile.h"
 #include "FileSystemHelper.h"
 #include <gtest/gtest.h>
-#include <system_error>
-#include <cstdint>
+
 
 const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
+
 
 TEST(LoggerFile, LogFileExists)
 {

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -17,7 +17,7 @@ TEST(LoggerFile, MessageLogged)
 {
 	LoggerFile logger;
 
-	const uintmax_t preFileSize = fs::file_size(logPath);
+	const auto preFileSize = fs::file_size(logPath);
 	EXPECT_NO_THROW(logger.Log("Test Log Message"));
 
 	ASSERT_GT(fs::file_size(logPath), preFileSize);

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -4,11 +4,13 @@
 #include <gtest/gtest.h>
 #include <fstream>
 
+
 // Set op2ext to operate in a test environment where Outpost2.exe is unavailable
 void EnableTestEnvironment();
 
 void SetupConsoleModTestEnvironment();
 void SetupIniFile();
+
 
 int main(int argc, char** argv) 
 {
@@ -20,6 +22,7 @@ int main(int argc, char** argv)
 
 	return RUN_ALL_TESTS();
 }
+
 
 void EnableTestEnvironment()
 {

--- a/test/ModuleLoader.test.cpp
+++ b/test/ModuleLoader.test.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <stdexcept>
 
+
 // Use to test that two modules with the same name but different casing is rejected from registering with the ModuleLoader
 // Windows file system and .ini key value pairs are case insensitive
 class DifferentCasedNameModule : public GameModule
@@ -15,6 +16,7 @@ public:
 	void Load() override {}
 	bool Unload() override { return true; }
 };
+
 
 TEST(ModuleLoader, NoModulesLoaded)
 {

--- a/test/op2ext.test.cpp
+++ b/test/op2ext.test.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 #include <array>
 
+
 using bufferType = std::array<char, 8>;
 
 


### PR DESCRIPTION
Just a bit of minor test code cleanup.

One of the changes was a bit odd and perplexing. It seems `auto` deduced a type that worked, but was perhaps a bit unexpected. Demonstration:
```
#include <type_traits>
const auto moduleName("NoDllTest");
static_assert(std::is_same_v<const char* const, decltype(moduleName)>);
```
There was of course no way for the compiler to deduce `std::string` from the `const char*` string literal. That seems to be what was intended though.

At any rate, the C-string was auto converted to a `std::string` later at the point of call to the `ConsoleModuleLoader`'s constructor.

Oh, and you don't need to include headers for types that are deduced with `auto`. The type will have already been visible by the code that produced the result value of that type, or the type will be a compiler built-in.
