### PR TITLE
Add `memoryPatchingEnabled`

### DIFF
--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -35,6 +35,7 @@ void SetLoadOffset()
 
 	if (op2ModuleBase == nullptr) {
 		PostError("Could not find Outpost2.exe module base address.");
+		return;
 	}
 
 	loadOffset = reinterpret_cast<std::size_t>(op2ModuleBase) - ExpectedOutpost2Addr;

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -48,7 +48,7 @@ void SetLoadOffset()
 template <typename Function>
 bool Op2MemEdit(void* destBaseAddr, std::size_t size, Function memoryEditFunction)
 {
-	if (memoryCommandsDisabled) {
+	if (!memoryPatchingEnabled) {
 		return false;
 	}
 
@@ -108,7 +108,7 @@ bool Op2MemSetDword(void* destBaseAddr, void* dword)
 // The `callOffset` parameter is the address of the encoded DWORD
 bool Op2RelinkCall(std::size_t callOffset, void* newFunctionAddress)
 {
-	if (memoryCommandsDisabled) {
+	if (!memoryPatchingEnabled) {
 		return false;
 	}
 
@@ -125,7 +125,7 @@ bool Op2RelinkCall(std::size_t callOffset, void* newFunctionAddress)
 
 bool Op2UnprotectMemory(std::size_t destBaseAddr, std::size_t size)
 {
-	if (memoryCommandsDisabled) {
+	if (!memoryPatchingEnabled) {
 		return false;
 	}
 	

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -28,10 +28,6 @@ void DisableMemoryCommands()
 // Adjust offsets in case Outpost2.exe module is relocated
 void SetLoadOffset()
 {
-	if (memoryCommandsDisabled) {
-		return;
-	}
-
 	void* op2ModuleBase = GetModuleHandle(TEXT("Outpost2.exe"));
 
 	if (op2ModuleBase == nullptr) {

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -6,7 +6,6 @@
 #include <iomanip>
 
 
-bool memoryCommandsDisabled;
 bool memoryPatchingEnabled = false;
 std::size_t loadOffset = 0;
 const std::size_t ExpectedOutpost2Addr = 0x00400000;
@@ -19,11 +18,6 @@ std::string AddrToHexString(std::size_t addr)
 	return stringStream.str();
 }
 
-
-void DisableMemoryCommands()
-{
-	memoryCommandsDisabled = true;
-}
 
 // Adjust offsets in case Outpost2.exe module is relocated
 void SetLoadOffset()

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -7,6 +7,7 @@
 
 
 bool memoryCommandsDisabled;
+bool memoryPatchingEnabled = false;
 std::size_t loadOffset = 0;
 const std::size_t ExpectedOutpost2Addr = 0x00400000;
 
@@ -38,6 +39,8 @@ void SetLoadOffset()
 		return;
 	}
 
+	// Enable memory patching for Outpost2.exe, and set relocation offset
+	memoryPatchingEnabled = true;
 	loadOffset = reinterpret_cast<std::size_t>(op2ModuleBase) - ExpectedOutpost2Addr;
 }
 

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -6,9 +6,6 @@
 #include <type_traits>
 
 
-// Disable memory commands when operating in test environment and Outpost2.exe is not available
-void DisableMemoryCommands();
-
 void SetLoadOffset();
 
 bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size);

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -5,9 +5,6 @@
 #include <fstream>
 
 
-// Set op2ext to operate in a test environment where Outpost2.exe is unavailable
-void EnableTestEnvironment();
-
 void SetupConsoleModTestEnvironment();
 void SetupIniFile();
 
@@ -16,18 +13,12 @@ int main(int argc, char** argv)
 {
 	::testing::InitGoogleTest(&argc, argv);
 
-	EnableTestEnvironment();
 	SetupConsoleModTestEnvironment();
 	SetupIniFile();
 
 	return RUN_ALL_TESTS();
 }
 
-
-void EnableTestEnvironment()
-{
-	DisableMemoryCommands();
-}
 
 void SetupConsoleModTestEnvironment()
 {

--- a/test/OP2Memory.test.cpp
+++ b/test/OP2Memory.test.cpp
@@ -2,16 +2,16 @@
 #include <gtest/gtest.h>
 
 
-extern bool memoryCommandsDisabled;
+extern bool memoryPatchingEnabled;
 
 
 class Op2RelinkCallTest : public ::testing::Test {
 protected:
   void SetUp() override {
-    memoryCommandsDisabled = false;
+    memoryPatchingEnabled = true;
   }
   void TearDown() override {
-    memoryCommandsDisabled = true;
+    memoryPatchingEnabled = false;
   }
 
   static constexpr unsigned char CallOpcode = 0xE8;


### PR DESCRIPTION
This reworks memory patching enabling/disabling to be more automated. Instead of explicit calls to disable patching, it relies on the already present setup calls to enable it. This allows memory patching to be enabled exactly when it is needed.

Edit: Tagging Issue #19 as related.
