### PR TITLE
Move `AddrToHexString` and `GetDateTime`

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -9,7 +9,6 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <string>
-#include <sstream>
 
 
 void LocateVolFiles(const std::string& relativeDirectory = "");

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -74,9 +74,7 @@ int TApp::Init()
 	bool success = Op2UnprotectMemory(destinationBaseAddress, 0x00587000 - 0x00585000);
 
 	if (!success) {
-		std::ostringstream stringStream;
-		stringStream << "Error unprotecting memory at: 0x" << std::hex << destinationBaseAddress << ".";
-		PostError(stringStream.str());
+		PostError("Error unprotecting memory at: 0x" + AddrToHexString(destinationBaseAddress));
 	}
 
 	// Order of precedence for loading vol files is:

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -4,7 +4,6 @@
 #include "OP2Memory.h"
 #include "FileSystemHelper.h"
 #include "Log.h"
-#include <sstream>
 #include <algorithm>
 #include <iterator>
 #include <stdexcept>

--- a/srcStatic/LoggerFile.cpp
+++ b/srcStatic/LoggerFile.cpp
@@ -15,5 +15,5 @@ LoggerFile::LoggerFile() :
 
 void LoggerFile::Log(const std::string& message, const std::string& moduleName)
 {
-	logFile << GetSystemDateTime() << " [" << moduleName << "] " << message << std::endl;
+	logFile << GetDateTime() << " [" << moduleName << "] " << message << std::endl;
 }

--- a/srcStatic/LoggerFile.cpp
+++ b/srcStatic/LoggerFile.cpp
@@ -1,13 +1,8 @@
 #include "LoggerFile.h"
 #include "Log.h"
 #include "FileSystemHelper.h"
+#include "StringConversion.h"
 #include <cstddef>
-#include <chrono>
-#include <ctime> //gmtime
-#include <iomanip> //put_time
-#include <sstream> // stringstream
-
-std::string GetSystemDateTime();
 
 
 LoggerFile::LoggerFile() :
@@ -21,20 +16,4 @@ LoggerFile::LoggerFile() :
 void LoggerFile::Log(const std::string& message, const std::string& moduleName)
 {
 	logFile << GetSystemDateTime() << " [" << moduleName << "] " << message << std::endl;
-}
-
-
-std::string GetSystemDateTime()
-{
-	auto currentClock = std::chrono::system_clock::now();
-	auto time = std::chrono::system_clock::to_time_t(currentClock);
-	std::tm unpackedTime;
-	if(gmtime_s(&unpackedTime, &time)) {
-		return "<Time conversion failed>";
-	}
-
-	std::stringstream stringStream;
-	stringStream << std::put_time(&unpackedTime, "%F %T UTC");
-
-	return stringStream.str();
 }

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -1,22 +1,13 @@
 #include "OP2Memory.h"
 #include "Log.h"
+#include "StringConversion.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <sstream>
-#include <iomanip>
 
 
 bool memoryCommandsDisabled;
 std::size_t loadOffset = 0;
 const std::size_t ExpectedOutpost2Addr = 0x00400000;
-
-
-std::string AddrToHexString(std::size_t addr)
-{
-	std::ostringstream stringStream;
-	stringStream << std::setfill('0') << std::setw(8) << std::hex << addr;
-	return stringStream.str();
-}
 
 
 void DisableMemoryCommands()

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -124,7 +124,7 @@ std::string AddrToHexString(std::size_t addr)
 }
 
 
-std::string GetSystemDateTime()
+std::string GetDateTime()
 {
 	auto currentClock = std::chrono::system_clock::now();
 	auto time = std::chrono::system_clock::to_time_t(currentClock);

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -134,7 +134,7 @@ std::string GetDateTime()
 	}
 
 	std::stringstream stringStream;
-	stringStream << std::put_time(&unpackedTime, "%F %T UTC");
+	stringStream << std::put_time(&unpackedTime, "%Y-%m-%d %H:%M:%S UTC");
 
 	return stringStream.str();
 }

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -6,6 +6,8 @@
 #include <algorithm>
 #include <locale>
 #include <codecvt>
+#include <chrono> // std::chrono::system_clock::now
+#include <ctime> // gmtime
 
 
 std::string WrapRawString(const char* str)
@@ -118,5 +120,21 @@ std::string AddrToHexString(std::size_t addr)
 {
 	std::ostringstream stringStream;
 	stringStream << std::setfill('0') << std::setw(8) << std::hex << addr;
+	return stringStream.str();
+}
+
+
+std::string GetSystemDateTime()
+{
+	auto currentClock = std::chrono::system_clock::now();
+	auto time = std::chrono::system_clock::to_time_t(currentClock);
+	std::tm unpackedTime;
+	if(gmtime_s(&unpackedTime, &time)) {
+		return "<Time conversion failed>";
+	}
+
+	std::stringstream stringStream;
+	stringStream << std::put_time(&unpackedTime, "%F %T UTC");
+
 	return stringStream.str();
 }

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -2,6 +2,7 @@
 #define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include "StringConversion.h"
 #include <sstream>
+#include <iomanip>
 #include <algorithm>
 #include <locale>
 #include <codecvt>
@@ -110,4 +111,12 @@ std::vector<std::string> Split(const std::string& stringToSplit, char delimiter)
 	}
 
 	return strings;
+}
+
+
+std::string AddrToHexString(std::size_t addr)
+{
+	std::ostringstream stringStream;
+	stringStream << std::setfill('0') << std::setw(8) << std::hex << addr;
+	return stringStream.str();
 }

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -52,3 +52,6 @@ std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter,
 	}
 	return items;
 }
+
+// Convert hex address value to string
+std::string AddrToHexString(std::size_t addr);

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -58,4 +58,4 @@ std::string AddrToHexString(std::size_t addr);
 
 
 // Gets UTC date/time string using the system clock
-std::string GetSystemDateTime();
+std::string GetDateTime();

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -55,3 +55,7 @@ std::vector<std::string> SplitAndTrim(std::string stringToSplit, char delimiter,
 
 // Convert hex address value to string
 std::string AddrToHexString(std::size_t addr);
+
+
+// Gets UTC date/time string using the system clock
+std::string GetSystemDateTime();

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -278,5 +278,7 @@ TEST(StringConversion, AddrToHexString)
 TEST(StringConversion, GetDateTime)
 {
 	auto dateTime = GetDateTime();
-	EXPECT_THAT(dateTime, ::testing::HasSubstr("UTC"));
+	EXPECT_THAT(dateTime, ::testing::HasSubstr("UTC")); // UTC time zone marker
+	EXPECT_THAT(dateTime, ::testing::ContainsRegex("\\d\\d\\d\\d-\\d\\d-\\d\\d")); // ISO 8601 date format
+	EXPECT_THAT(dateTime, ::testing::ContainsRegex("\\d\\d:\\d\\d:\\d\\d")); // ISO 8601 time format
 }

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -263,3 +263,13 @@ TEST(StringConversion, SplitAndTrimTrimFront)
 	EXPECT_EQ((std::vector<std::string>{"A ", "B ", "C"}), SplitAndTrim<TrimFront>("A ,B ,C", ','));
 	EXPECT_EQ((std::vector<std::string>{"A ", "B ", "C"}), SplitAndTrim<TrimFront>("A , B , C", ','));
 }
+
+
+TEST(StringConversion, AddrToHexString)
+{
+	// Correctly pads with 0
+	EXPECT_EQ("00000000", AddrToHexString(0));
+	EXPECT_EQ("00000000", AddrToHexString(00000000));
+	// Note casing of hex values
+	EXPECT_EQ("deadbeef", AddrToHexString(0xDEADBEEF));
+}

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -1,5 +1,6 @@
 #include "StringConversion.h"
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <string>
 #include <type_traits>
 
@@ -272,4 +273,10 @@ TEST(StringConversion, AddrToHexString)
 	EXPECT_EQ("00000000", AddrToHexString(00000000));
 	// Note casing of hex values
 	EXPECT_EQ("deadbeef", AddrToHexString(0xDEADBEEF));
+}
+
+TEST(StringConversion, GetDateTime)
+{
+	auto dateTime = GetDateTime();
+	EXPECT_THAT(dateTime, ::testing::HasSubstr("UTC"));
 }


### PR DESCRIPTION
The `AddrToHexString` and `GetDateTime` methods are fairly general in their use. This moves them to a more publicly visible place.

Unit tests were added for these methods. The `GetDateTime` method was fixed so that it actually works on Linux with Mingw. Previously log messages had empty strings for the timestamps.
