### PR TITLE
Build out multiple console modules support

### DIFF
--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -97,12 +97,6 @@ void ConsoleModuleLoader::LoadModules()
 
 	// Load all module DLLs
 	for (auto& module : modules) {
-		std::error_code errorCode;
-		if (!fs::is_directory(module.directory, errorCode)) {
-			PostError("Unable to access the provided module directory. " + errorCode.message());
-			continue;
-		}
-
 		LoadModuleDll(module);
 	}
 }

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -23,6 +23,11 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 		return; // No console modules to load
 	}
 
+	if (std::any_of(moduleNames.begin(), moduleNames.end(), [](const std::string& moduleName){ return moduleName.empty(); })) {
+		PostError("All console module names must be non-empty.");
+		return;
+	}
+
 	// For now just handle the first name
 	if (moduleNames.size() > 1) {
 		throw std::runtime_error("ConsoleModuleLoader currently only supports a single loaded module");

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -33,7 +33,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 
 		std::error_code errorCode;
 		if (!fs::is_directory(moduleDirectory, errorCode)) {
-			PostError("Unable to access the provided module directory. " + errorCode.message());
+			PostError("Unable to access the provided module directory: " + moduleName + " : "+ errorCode.message());
 			continue;
 		}
 

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -18,15 +18,16 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 		return; // No console modules to load
 	}
 
+	// Temporary check. This will eventually become an error.
+	if (moduleNames.size() == 1 && moduleNames[0].empty()) {
+		return; // No console modules to load
+	}
+
 	// For now just handle the first name
 	if (moduleNames.size() > 1) {
 		throw std::runtime_error("ConsoleModuleLoader currently only supports a single loaded module");
 	}
 	auto moduleName = moduleNames[0];
-
-	if (moduleName.empty()) {
-		return; // No Console Module Loaded
-	}
 
 	auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleName).string();
 

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -87,21 +87,22 @@ bool ConsoleModuleLoader::IsModuleLoaded(std::string moduleName)
 
 void ConsoleModuleLoader::LoadModules()
 {
-	// Get access to private static
-	auto moduleDirectory = ModuleDirectory();
-
 	// Abort early to avoid hooking file search path if not needed
 	if (modules.empty()) {
 		return;
 	}
+
+	// Setup loading of additional resources from module folders
+	HookFileSearchPath();
+
+	// Get access to private static
+	auto moduleDirectory = ModuleDirectory();
 
 	std::error_code errorCode;
 	if (!fs::is_directory(moduleDirectory, errorCode)) {
 		PostError("Unable to access the provided module directory. " + errorCode.message());
 		return;
 	}
-
-	HookFileSearchPath();
 
 	// Load all module DLLs
 	for (auto& module : modules) {

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -32,21 +32,23 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 	if (moduleNames.size() > 1) {
 		throw std::runtime_error("ConsoleModuleLoader currently only supports a single loaded module");
 	}
-	auto moduleName = moduleNames[0];
 
-	auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleName).string();
+	for (auto& moduleName : moduleNames) {
+		auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleName).string();
 
-	std::error_code errorCode;
-	if (!fs::is_directory(moduleDirectory, errorCode)) {
-		PostError("Unable to access the provided module directory. " + errorCode.message());
-		moduleDirectory = "";
-		moduleName = "";
+		std::error_code errorCode;
+		if (!fs::is_directory(moduleDirectory, errorCode)) {
+			PostError("Unable to access the provided module directory. " + errorCode.message());
+			continue;
+		}
+
+		// Store module details
+		modules.push_back({nullptr, moduleName});
+
+		// Set private static instance by reference
+		// This is still only storing a single directory, which gets overwritten each loop iteration
+		ModuleDirectory() = moduleDirectory;
 	}
-
-	// Store module details
-	modules.push_back({nullptr, moduleName});
-	// Set private static instance by reference
-	ModuleDirectory() = moduleDirectory;
 }
 
 std::string ConsoleModuleLoader::GetModuleDirectory(std::size_t index)

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -90,7 +90,8 @@ void ConsoleModuleLoader::LoadModules()
 	// Get access to private static
 	auto moduleDirectory = ModuleDirectory();
 
-	if (moduleDirectory.empty()) {
+	// Abort early to avoid hooking file search path if not needed
+	if (modules.empty()) {
 		return;
 	}
 

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -67,8 +67,9 @@ std::size_t ConsoleModuleLoader::Count()
 // Returns false if passed an empty string (Module name cannot be empty)
 bool ConsoleModuleLoader::IsModuleLoaded(std::string moduleName)
 {
+	ToLowerInPlace(moduleName);
 	for (std::size_t i = 0; i < Count(); ++i) {
-		if (ToLowerInPlace(moduleName) == ToLower(GetModuleName(i))) {
+		if (moduleName == ToLower(GetModuleName(i))) {
 			return true;
 		}
 	}

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -22,14 +22,13 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 	if (moduleNames.size() > 1) {
 		throw std::runtime_error("ConsoleModuleLoader currently only supports a single loaded module");
 	}
-	auto moduleRelativeDirectory = moduleNames[0];
+	auto moduleName = moduleNames[0];
 
-	if (moduleRelativeDirectory.empty()) {
+	if (moduleName.empty()) {
 		return; // No Console Module Loaded
 	}
 
-	auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleRelativeDirectory).string();
-	auto moduleName = moduleRelativeDirectory;
+	auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleName).string();
 
 	std::error_code errorCode;
 	if (!fs::is_directory(moduleDirectory, errorCode)) {

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -28,11 +28,6 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 		return;
 	}
 
-	// For now just handle the first name
-	if (moduleNames.size() > 1) {
-		throw std::runtime_error("ConsoleModuleLoader currently only supports a single loaded module");
-	}
-
 	for (auto& moduleName : moduleNames) {
 		auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleName).string();
 

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -28,7 +28,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 		return;
 	}
 
-	for (auto& moduleName : moduleNames) {
+	for (const auto& moduleName : moduleNames) {
 		auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleName).string();
 
 		std::error_code errorCode;
@@ -179,7 +179,7 @@ bool ConsoleModuleLoader::ResManager::GetFilePath(const char* resourceName, /* [
 
 void ConsoleModuleLoader::UnloadModules()
 {
-	for (auto& module : modules) {
+	for (const auto& module : modules) {
 		if (module.dllHandle)
 		{
 			FARPROC destroyModFunc = GetProcAddress(module.dllHandle, "mod_destroy");
@@ -194,7 +194,7 @@ void ConsoleModuleLoader::UnloadModules()
 
 void ConsoleModuleLoader::RunModules()
 {
-	for (auto& module : modules) {
+	for (const auto& module : modules) {
 		// Startup a module by calling its run func
 		if (module.dllHandle)
 		{

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -32,7 +32,7 @@ private:
 	void LoadModuleDll(Module& moduleInfo);
 	void HookFileSearchPath();
 	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
-	static std::string& ModuleDirectory();
+	static std::vector<std::string>& ModuleDirectories();
 
 	// For compatibility with Outpost2.exe's built in class
 	class ResManager {

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -24,6 +24,7 @@ private:
 	struct Module {
 		HINSTANCE dllHandle = nullptr;
 		std::string name;
+		std::string directory;
 	};
 
 	std::vector<Module> modules;

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -21,10 +21,14 @@ public:
 	bool IsModuleLoaded(std::string moduleName);
 
 private:
-	HINSTANCE modDllHandle = nullptr;
-	std::string moduleName;
+	struct Module {
+		HINSTANCE dllHandle = nullptr;
+		std::string name;
+	};
 
-	void LoadModuleDll();
+	Module module;
+
+	void LoadModuleDll(Module& moduleInfo);
 	void HookFileSearchPath();
 	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
 	static std::string& ModuleDirectory();

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -26,7 +26,7 @@ private:
 		std::string name;
 	};
 
-	Module module;
+	std::vector<Module> modules;
 
 	void LoadModuleDll(Module& moduleInfo);
 	void HookFileSearchPath();

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -91,9 +91,9 @@ TEST(ConsoleModuleLoader, MultiModule) {
 	EXPECT_NO_THROW(consoleModuleLoader.RunModules());
 	EXPECT_NO_THROW(consoleModuleLoader.UnloadModules());
 
-	// // Cleanup test module directories
-	// for (const auto& moduleName : moduleNames) {
-	// 	// Bug: This doesn't work under Mingw
-	// 	fs::remove(exeDir / moduleName);
-	// }
+	// Cleanup test module directories
+	for (const auto& moduleName : moduleNames) {
+		// Use Win API directly since fs::remove doesn't work under Mingw
+		EXPECT_NE(0, RemoveDirectoryW((exeDir / moduleName).wstring().c_str()));
+	}
 }

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -66,3 +66,34 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 	EXPECT_NO_THROW(consoleModuleLoader.RunModules());
 	EXPECT_NO_THROW(consoleModuleLoader.UnloadModules());
 }
+
+TEST(ConsoleModuleLoader, MultiModule) {
+	const auto exeDir = fs::path(GetGameDirectory());
+	const std::vector<std::string> moduleNames{"Module1", "Module2"};
+
+	// Create some empty test module directories
+	for (const auto& moduleName : moduleNames) {
+		fs::create_directory(exeDir / moduleName);
+	}
+
+	ConsoleModuleLoader consoleModuleLoader(moduleNames);
+
+	EXPECT_EQ(2u, consoleModuleLoader.Count());
+	EXPECT_EQ(moduleNames[0], consoleModuleLoader.GetModuleName(0));
+	EXPECT_EQ(moduleNames[1], consoleModuleLoader.GetModuleName(1));
+
+	EXPECT_TRUE(consoleModuleLoader.IsModuleLoaded(moduleNames[0]));
+	EXPECT_TRUE(consoleModuleLoader.IsModuleLoaded(moduleNames[1]));
+
+	EXPECT_FALSE(consoleModuleLoader.IsModuleLoaded(""));
+
+	EXPECT_NO_THROW(consoleModuleLoader.LoadModules());
+	EXPECT_NO_THROW(consoleModuleLoader.RunModules());
+	EXPECT_NO_THROW(consoleModuleLoader.UnloadModules());
+
+	// // Cleanup test module directories
+	// for (const auto& moduleName : moduleNames) {
+	// 	// Bug: This doesn't work under Mingw
+	// 	fs::remove(exeDir / moduleName);
+	// }
+}

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -28,9 +28,13 @@ TEST(ConsoleModuleLoader, NoModuleLoaded)
 TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 {
 	const std::string moduleName("NoDllTest");
+
+	// Test will need temporary module directory with no DLL present
+	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
+	fs::create_directory(moduleDirectory);
+
 	ConsoleModuleLoader consoleModuleLoader({moduleName});
 
-	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
 	EXPECT_EQ(moduleDirectory, consoleModuleLoader.GetModuleDirectory(0));
 	EXPECT_EQ(moduleName, consoleModuleLoader.GetModuleName(0));
 
@@ -43,6 +47,10 @@ TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 	EXPECT_NO_THROW(consoleModuleLoader.LoadModules());
 	EXPECT_NO_THROW(consoleModuleLoader.RunModules());
 	EXPECT_NO_THROW(consoleModuleLoader.UnloadModules());
+
+	// Cleanup test module directory
+	// Use Win API directly since fs::remove doesn't work under Mingw
+	EXPECT_NE(0, RemoveDirectoryW(moduleDirectory.wstring().c_str()));
 }
 
 TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -5,7 +5,6 @@
 #include <fstream>
 
 
-void SetupConsoleModTestEnvironment();
 void SetupIniFile();
 
 
@@ -13,25 +12,11 @@ int main(int argc, char** argv)
 {
 	::testing::InitGoogleTest(&argc, argv);
 
-	SetupConsoleModTestEnvironment();
 	SetupIniFile();
 
 	return RUN_ALL_TESTS();
 }
 
-
-void SetupConsoleModTestEnvironment()
-{
-	fs::path gameDirectory(GetGameDirectory());
-
-	fs::create_directory(gameDirectory / "NoDllTest");
-
-	fs::path emptyModuleTestDirectory = gameDirectory / "InvalidDllTest";
-
-	fs::create_directory(emptyModuleTestDirectory);
-	std::ofstream stream((emptyModuleTestDirectory / "op2mod.dll").string());
-	stream.close();
-}
 
 void SetupIniFile()
 {


### PR DESCRIPTION
This extends the `ConsoleModuleLoader` class to  add support for loading multiple console modules.

Not covered are updates to the command line argument processing, which would be needed to pass multiple module names to the `ConsoleModuleLoader`'s constructor.

This work supports Issue #100. This is the internal changes that correspond to the interfaces changes in PR #160.
