### PR TITLE
Refactor `GetFilePath` hook

### DIFF
--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -1,20 +1,13 @@
 #include "ConsoleModuleLoader.h"
+#include "ResourceSearchPath.h"
 #include "StringConversion.h"
 #include "WindowsErrorCode.h"
-#include "OP2Memory.h"
 #include "FileSystemHelper.h"
 #include "Log.h"
 #include <algorithm>
 #include <iterator>
 #include <stdexcept>
 #include <system_error>
-
-
-// For compatibility with Outpost2.exe's built in class
-class ResManager {
-public:
-	bool GetFilePath(const char* resourceName, /* [out] */ char* filePath) const;
-};
 
 
 // Console module names are the relative path from the game folder (no trailing slash)
@@ -132,63 +125,6 @@ void ConsoleModuleLoader::LoadModuleDll(Module& module)
 	}
 }
 
-void ResourceSearchPath::HookFileSearchPath()
-{
-	const std::vector<std::size_t> callsToGetFilePath{
-		0x00402E4B,
-		0x004038A9,
-		0x0045003C,
-		0x0045035D,
-		0x0046078C,
-		0x00460B13,
-		0x00471089,
-		0x0047118B,
-		0x0047121E,
-		0x004712B7,
-		0x00485C69,
-		0x004882CB,
-		0x00488967,
-		0x00489433,
-		0x004977E4,
-	};
-	// Convert a pointer to member function to a regular `void*` value
-	auto getFilePath = &ResManager::GetFilePath;
-	const auto getFilePathAddr = reinterpret_cast<void*&>(getFilePath);  // MSVC specific cast
-
-	for (const auto callAddr : callsToGetFilePath) {
-		Op2RelinkCall(callAddr, getFilePathAddr);
-	}
-}
-
-bool ResourceSearchPath::CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath)
-{
-	// Use Outpost2.exe's built in ResManager object, and its associated member function
-	ResManager& resManager = *reinterpret_cast<ResManager*>(0x56C028);
-	auto originalGetFilePath = GetMethodPointer<decltype(&ResManager::GetFilePath)>(0x00471590);
-	return (resManager.*originalGetFilePath)(resourceName, filePath);
-}
-
-bool ResManager::GetFilePath(const char* resourceName, /* [out] */ char* filePath) const
-{
-	// Get access to private static
-	auto moduleDirectories = ResourceSearchPath::ModuleDirectories();
-
-	for (const auto& moduleDirectory : moduleDirectories) {
-		// Search for resource in module folder
-		const auto path = moduleDirectory + resourceName;
-		if (INVALID_FILE_ATTRIBUTES != GetFileAttributesA(path.c_str())) {
-			if (0 == CopyStdStringIntoCharBuffer(path, filePath, MAX_PATH)) {
-				return true; // Resource found
-			} else {
-				Log("MAX_PATH exceeded while trying to return path to resource: " + std::string(resourceName));
-			}
-		}
-	}
-
-	// Fallback to searching with the original built in method
-	return ResourceSearchPath::CallOriginalGetFilePath(resourceName, filePath);
-}
-
 void ConsoleModuleLoader::UnloadModules()
 {
 	for (const auto& module : modules) {
@@ -217,23 +153,4 @@ void ConsoleModuleLoader::RunModules()
 			}
 		}
 	}
-}
-
-void ResourceSearchPath::Set(std::vector<std::string> paths)
-{
-	ModuleDirectories() = std::move(paths);
-}
-
-void ResourceSearchPath::Activate()
-{
-	HookFileSearchPath();
-}
-
-std::vector<std::string>& ResourceSearchPath::ModuleDirectories()
-{
-	// Function level statics are initialized on first use
-	// They are not subject to unsequenced initialization order of globals
-	// There is no order dependency on when this variable may be used
-	static std::vector<std::string> moduleDirectories;
-	return moduleDirectories;
 }

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -54,7 +54,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 		moduleDirectories.push_back(module.directory);
 	}
 	// Add module directories to resource search path
-	ResourceSearchPath::ModuleDirectories() = std::move(moduleDirectories);
+	ResourceSearchPath::Set(std::move(moduleDirectories));
 }
 
 std::string ConsoleModuleLoader::GetModuleDirectory(std::size_t index)
@@ -99,7 +99,7 @@ void ConsoleModuleLoader::LoadModules()
 	}
 
 	// Setup loading of additional resources from module folders
-	ResourceSearchPath::HookFileSearchPath();
+	ResourceSearchPath::Activate();
 
 	// Load all module DLLs
 	for (auto& module : modules) {
@@ -217,6 +217,16 @@ void ConsoleModuleLoader::RunModules()
 			}
 		}
 	}
+}
+
+void ResourceSearchPath::Set(std::vector<std::string> paths)
+{
+	ModuleDirectories() = std::move(paths);
+}
+
+void ResourceSearchPath::Activate()
+{
+	HookFileSearchPath();
 }
 
 std::vector<std::string>& ResourceSearchPath::ModuleDirectories()

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -38,10 +38,16 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 
 		// Store module details
 		modules.push_back({nullptr, moduleName, moduleDirectory});
-
-		// Add to private static instance by reference
-		ModuleDirectories().push_back(moduleDirectory);
 	}
+
+	// Build list of module directories
+	std::vector<std::string> moduleDirectories;
+	moduleDirectories.reserve(modules.size());
+	for (const auto& module: modules) {
+		moduleDirectories.push_back(module.directory);
+	}
+	// Add module directories to resource search path
+	ModuleDirectories() = std::move(moduleDirectories);
 }
 
 std::string ConsoleModuleLoader::GetModuleDirectory(std::size_t index)

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -6,9 +6,6 @@
 #include <cstddef>
 
 
-class ResManager;
-
-
 class ConsoleModuleLoader {
 public:
 	ConsoleModuleLoader(const std::vector<std::string>& moduleNames);
@@ -33,9 +30,19 @@ private:
 	std::vector<Module> modules;
 
 	void LoadModuleDll(Module& moduleInfo);
+};
 
-	friend ResManager;
+
+class ResManager;
+
+
+class ResourceSearchPath {
+public:
 	static void HookFileSearchPath();
+
+private:
+	friend ResManager;
+	friend ConsoleModuleLoader;
 	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
 	static std::vector<std::string>& ModuleDirectories();
 };

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -38,11 +38,12 @@ class ResManager;
 
 class ResourceSearchPath {
 public:
-	static void HookFileSearchPath();
+	static void Set(std::vector<std::string> paths);
+	static void Activate();
 
 private:
 	friend ResManager;
-	friend ConsoleModuleLoader;
+	static void HookFileSearchPath();
 	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
 	static std::vector<std::string>& ModuleDirectories();
 };

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -31,19 +31,3 @@ private:
 
 	void LoadModuleDll(Module& moduleInfo);
 };
-
-
-class ResManager;
-
-
-class ResourceSearchPath {
-public:
-	static void Set(std::vector<std::string> paths);
-	static void Activate();
-
-private:
-	friend ResManager;
-	static void HookFileSearchPath();
-	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
-	static std::vector<std::string>& ModuleDirectories();
-};

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -35,7 +35,7 @@ private:
 	void LoadModuleDll(Module& moduleInfo);
 
 	friend ResManager;
-	void HookFileSearchPath();
+	static void HookFileSearchPath();
 	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
 	static std::vector<std::string>& ModuleDirectories();
 };

--- a/srcStatic/ConsoleModuleLoader.h
+++ b/srcStatic/ConsoleModuleLoader.h
@@ -6,6 +6,9 @@
 #include <cstddef>
 
 
+class ResManager;
+
+
 class ConsoleModuleLoader {
 public:
 	ConsoleModuleLoader(const std::vector<std::string>& moduleNames);
@@ -30,13 +33,9 @@ private:
 	std::vector<Module> modules;
 
 	void LoadModuleDll(Module& moduleInfo);
+
+	friend ResManager;
 	void HookFileSearchPath();
 	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
 	static std::vector<std::string>& ModuleDirectories();
-
-	// For compatibility with Outpost2.exe's built in class
-	class ResManager {
-	public:
-		bool GetFilePath(const char* resourceName, /* [out] */ char* filePath) const;
-	};
 };

--- a/srcStatic/ResourceSearchPath.cpp
+++ b/srcStatic/ResourceSearchPath.cpp
@@ -1,0 +1,92 @@
+#include "ResourceSearchPath.h"
+#include "StringConversion.h"
+#include "OP2Memory.h"
+#include "Log.h"
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+
+// For compatibility with Outpost2.exe's built in class
+class ResManager {
+public:
+	bool GetFilePath(const char* resourceName, /* [out] */ char* filePath) const;
+};
+
+
+void ResourceSearchPath::Set(std::vector<std::string> paths)
+{
+	ModuleDirectories() = std::move(paths);
+}
+
+void ResourceSearchPath::Activate()
+{
+	HookFileSearchPath();
+}
+
+
+std::vector<std::string>& ResourceSearchPath::ModuleDirectories()
+{
+	// Function level statics are initialized on first use
+	// They are not subject to unsequenced initialization order of globals
+	// There is no order dependency on when this variable may be used
+	static std::vector<std::string> moduleDirectories;
+	return moduleDirectories;
+}
+
+void ResourceSearchPath::HookFileSearchPath()
+{
+	const std::vector<std::size_t> callsToGetFilePath{
+		0x00402E4B,
+		0x004038A9,
+		0x0045003C,
+		0x0045035D,
+		0x0046078C,
+		0x00460B13,
+		0x00471089,
+		0x0047118B,
+		0x0047121E,
+		0x004712B7,
+		0x00485C69,
+		0x004882CB,
+		0x00488967,
+		0x00489433,
+		0x004977E4,
+	};
+	// Convert a pointer to member function to a regular `void*` value
+	auto getFilePath = &ResManager::GetFilePath;
+	const auto getFilePathAddr = reinterpret_cast<void*&>(getFilePath);  // MSVC specific cast
+
+	for (const auto callAddr : callsToGetFilePath) {
+		Op2RelinkCall(callAddr, getFilePathAddr);
+	}
+}
+
+bool ResourceSearchPath::CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath)
+{
+	// Use Outpost2.exe's built in ResManager object, and its associated member function
+	ResManager& resManager = *reinterpret_cast<ResManager*>(0x56C028);
+	auto originalGetFilePath = GetMethodPointer<decltype(&ResManager::GetFilePath)>(0x00471590);
+	return (resManager.*originalGetFilePath)(resourceName, filePath);
+}
+
+
+bool ResManager::GetFilePath(const char* resourceName, /* [out] */ char* filePath) const
+{
+	// Get access to private static
+	auto moduleDirectories = ResourceSearchPath::ModuleDirectories();
+
+	for (const auto& moduleDirectory : moduleDirectories) {
+		// Search for resource in module folder
+		const auto path = moduleDirectory + resourceName;
+		if (INVALID_FILE_ATTRIBUTES != GetFileAttributesA(path.c_str())) {
+			if (0 == CopyStdStringIntoCharBuffer(path, filePath, MAX_PATH)) {
+				return true; // Resource found
+			} else {
+				Log("MAX_PATH exceeded while trying to return path to resource: " + std::string(resourceName));
+			}
+		}
+	}
+
+	// Fallback to searching with the original built in method
+	return ResourceSearchPath::CallOriginalGetFilePath(resourceName, filePath);
+}

--- a/srcStatic/ResourceSearchPath.h
+++ b/srcStatic/ResourceSearchPath.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+class ResManager;
+
+
+class ResourceSearchPath {
+public:
+	static void Set(std::vector<std::string> paths);
+	static void Activate();
+
+private:
+	friend ResManager;
+	static void HookFileSearchPath();
+	static bool CallOriginalGetFilePath(const char* resourceName, /* [out] */ char* filePath);
+	static std::vector<std::string>& ModuleDirectories();
+};

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="LoggerFile.cpp" />
     <ClCompile Include="LoggerMessageBox.cpp" />
     <ClCompile Include="OP2Memory.cpp" />
+    <ClCompile Include="ResourceSearchPath.cpp" />
     <ClCompile Include="StringConversion.cpp" />
     <ClCompile Include="VolList.cpp" />
     <ClCompile Include="WindowsErrorCode.cpp" />
@@ -159,6 +160,7 @@
     <ClInclude Include="LoggerFile.h" />
     <ClInclude Include="LoggerMessageBox.h" />
     <ClInclude Include="OP2Memory.h" />
+    <ClInclude Include="ResourceSearchPath.h" />
     <ClInclude Include="StringConversion.h" />
     <ClInclude Include="VolList.h" />
     <ClInclude Include="WindowsErrorCode.h" />

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -10,6 +10,7 @@
     <ClCompile Include="LoggerFile.cpp"/>
     <ClCompile Include="LoggerMessageBox.cpp"/>
     <ClCompile Include="OP2Memory.cpp" />
+    <ClCompile Include="ResourceSearchPath.cpp" />
     <ClCompile Include="StringConversion.cpp" />
     <ClCompile Include="VolList.cpp" />
     <ClCompile Include="WindowsErrorCode.cpp" />
@@ -33,6 +34,7 @@
     <ClInclude Include="LoggerFile.h"/>
     <ClInclude Include="LoggerMessageBox.h"/>
     <ClInclude Include="OP2Memory.h" />
+    <ClInclude Include="ResourceSearchPath.h" />
     <ClInclude Include="StringConversion.h" />
     <ClInclude Include="VolList.h" />
     <ClInclude Include="WindowsErrorCode.h" />


### PR DESCRIPTION
This is some cleanup intended to support Issue #175. It splits responsibility for handling alternate resource paths into a separate `ResourceSearchPath` class, distinct from the `ConsoleModuleLoader`. Hopefully the split in responsibilities leads to easier testing.

The split was originally done in-file to minimize the diff noise, then later the new class was moved to a new file.

I originally planned to address the bug in Issue #175, but I need to stop for a bit, and this seemed like a good stopping point. Changes should be quite self contained.
