### PR TITLE
Fix console module resource loading

### DIFF
--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -53,7 +53,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 std::string ConsoleModuleLoader::GetModuleDirectory(std::size_t index)
 {
 	if (index >= modules.size()) {
-		throw std::runtime_error("Invalid console module index: " + std::to_string(index));
+		throw std::runtime_error("GetModuleDirectory: Invalid console module index: " + std::to_string(index));
 	}
 	// Return copy of private static
 	return modules[index].directory;
@@ -62,7 +62,7 @@ std::string ConsoleModuleLoader::GetModuleDirectory(std::size_t index)
 std::string ConsoleModuleLoader::GetModuleName(std::size_t index)
 {
 	if (index >= modules.size()) {
-		throw std::runtime_error("Invalid console module index: " + std::to_string(index));
+		throw std::runtime_error("GetModuleName: Invalid console module index: " + std::to_string(index));
 	}
 	return modules[index].name;
 }

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -28,7 +28,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 	}
 
 	for (const auto& moduleName : moduleNames) {
-		auto moduleDirectory = fs::path(GetGameDirectory()).append(moduleName).string();
+		auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
 
 		std::error_code errorCode;
 		if (!fs::is_directory(moduleDirectory, errorCode)) {
@@ -37,7 +37,8 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 		}
 
 		// Store module details
-		modules.push_back({nullptr, moduleName, moduleDirectory});
+		// Make sure module directory ends with a trailing slash
+		modules.push_back({nullptr, moduleName, (moduleDirectory / "\\").string()});
 	}
 
 	// Build list of module directories

--- a/srcStatic/ConsoleModuleLoader.cpp
+++ b/srcStatic/ConsoleModuleLoader.cpp
@@ -38,7 +38,7 @@ ConsoleModuleLoader::ConsoleModuleLoader(const std::vector<std::string>& moduleN
 
 		// Store module details
 		// Make sure module directory ends with a trailing slash
-		modules.push_back({nullptr, moduleName, (moduleDirectory / "\\").string()});
+		modules.push_back({nullptr, moduleName, moduleDirectory.string() + "\\"});
 	}
 
 	// Build list of module directories

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -35,7 +35,7 @@ TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 
 	ConsoleModuleLoader consoleModuleLoader({moduleName});
 
-	EXPECT_EQ(moduleDirectory, consoleModuleLoader.GetModuleDirectory(0));
+	EXPECT_EQ(moduleDirectory.string(), consoleModuleLoader.GetModuleDirectory(0));
 	EXPECT_EQ(moduleName, consoleModuleLoader.GetModuleName(0));
 
 	EXPECT_TRUE(consoleModuleLoader.IsModuleLoaded(moduleName));
@@ -68,7 +68,7 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 
 	ConsoleModuleLoader consoleModuleLoader({moduleName});
 
-	EXPECT_EQ(moduleDirectory, consoleModuleLoader.GetModuleDirectory(0));
+	EXPECT_EQ(moduleDirectory.string(), consoleModuleLoader.GetModuleDirectory(0));
 	EXPECT_EQ(moduleName, consoleModuleLoader.GetModuleName(0));
 
 	EXPECT_TRUE(consoleModuleLoader.IsModuleLoaded(moduleName));

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -30,7 +30,8 @@ TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 	const std::string moduleName("NoDllTest");
 
 	// Test will need temporary module directory with no DLL present
-	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
+	// Ensure module directory ends with a trailing slash
+	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName / "\\";
 	fs::create_directory(moduleDirectory);
 
 	ConsoleModuleLoader consoleModuleLoader({moduleName});
@@ -58,7 +59,8 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 	const std::string moduleName("InvalidDllTest");
 
 	// Test will need temporary module directory and invalid DLL file
-	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
+	// Ensure module directory ends with a trailing slash
+	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName / "\\";
 	const auto dllFile = moduleDirectory / "op2mod.dll";
 	// Create temporary module directory
 	fs::create_directory(moduleDirectory);

--- a/test/ConsolueModuleLoader.test.cpp
+++ b/test/ConsolueModuleLoader.test.cpp
@@ -31,12 +31,12 @@ TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 
 	// Test will need temporary module directory with no DLL present
 	// Ensure module directory ends with a trailing slash
-	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName / "\\";
+	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
 	fs::create_directory(moduleDirectory);
 
 	ConsoleModuleLoader consoleModuleLoader({moduleName});
 
-	EXPECT_EQ(moduleDirectory.string(), consoleModuleLoader.GetModuleDirectory(0));
+	EXPECT_EQ(moduleDirectory.string() + "\\", consoleModuleLoader.GetModuleDirectory(0));
 	EXPECT_EQ(moduleName, consoleModuleLoader.GetModuleName(0));
 
 	EXPECT_TRUE(consoleModuleLoader.IsModuleLoaded(moduleName));
@@ -60,7 +60,7 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 
 	// Test will need temporary module directory and invalid DLL file
 	// Ensure module directory ends with a trailing slash
-	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName / "\\";
+	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
 	const auto dllFile = moduleDirectory / "op2mod.dll";
 	// Create temporary module directory
 	fs::create_directory(moduleDirectory);
@@ -70,7 +70,7 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 
 	ConsoleModuleLoader consoleModuleLoader({moduleName});
 
-	EXPECT_EQ(moduleDirectory.string(), consoleModuleLoader.GetModuleDirectory(0));
+	EXPECT_EQ(moduleDirectory.string() + "\\", consoleModuleLoader.GetModuleDirectory(0));
 	EXPECT_EQ(moduleName, consoleModuleLoader.GetModuleName(0));
 
 	EXPECT_TRUE(consoleModuleLoader.IsModuleLoaded(moduleName));


### PR DESCRIPTION
This fixes #175. Include trailing slashes in console module directory names to ensure proper path concatenation.
