### PR TITLE
Fix init error reporting

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -1,4 +1,5 @@
 #include "Globals.h"
+#include "ConsoleArgumentParser.h"
 #include "ModuleLoader.h"
 #include "StringConversion.h"
 #include "OP2Memory.h"
@@ -50,6 +51,11 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 		// Setup logging
 		SetLogger(&loggerFile);
 		SetLoggerError(&loggerMessageBox);
+
+		// Construct global objects
+		volList = std::make_unique<VolList>();
+		consoleModuleLoader = std::make_unique<ConsoleModuleLoader>(std::vector{FindModuleDirectory()});
+		moduleLoader = std::make_unique<ModuleLoader>();
 
 		// Set load offset for Outpost2.exe module, used during memory patching
 		SetLoadOffset();

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -80,20 +80,20 @@ int TApp::Init()
 	// ART_PATH (from console module), Console Module, Ini Modules, Addon directory, Game directory
 
 	// Load command line modules
-	consoleModuleLoader.LoadModules();
+	consoleModuleLoader->LoadModules();
 
 	// Load all active modules from the .ini file
-	moduleLoader.LoadModules();
+	moduleLoader->LoadModules();
 
 	// Find VOL files from additional folders
-	for (std::size_t i = 0; i < consoleModuleLoader.Count(); ++i) {
+	for (std::size_t i = 0; i < consoleModuleLoader->Count(); ++i) {
 		// ConsoleModule name matches relative folder from game exeucutable folder
-		LocateVolFiles(consoleModuleLoader.GetModuleName(i));
+		LocateVolFiles(consoleModuleLoader->GetModuleName(i));
 	}
 	LocateVolFiles("Addon");
 	LocateVolFiles(); //Searches root directory
 
-	volList.LoadVolFiles();
+	volList->LoadVolFiles();
 
 	// Replace call to LoadLibrary with custom routine (address is indirect)
 	Op2MemSetDword(loadLibraryDataAddr, (int)&loadLibraryNewAddr);
@@ -110,8 +110,8 @@ void TApp::ShutDown()
 	// Call original function
 	(this->*GetMethodPointer<decltype(&TApp::ShutDown)>(0x004866E0))();
 
-	consoleModuleLoader.UnloadModules();
-	moduleLoader.UnloadModules();
+	consoleModuleLoader->UnloadModules();
+	moduleLoader->UnloadModules();
 }
 
 /**
@@ -137,7 +137,7 @@ void LocateVolFiles(const std::string& relativeDirectory)
 			const auto extension = ToLower(filePath.extension().string());
 
 			if (extension == ".vol") {
-				volList.AddVolFile((fs::path(relativeDirectory) / filePath.filename()).string());
+				volList->AddVolFile((fs::path(relativeDirectory) / filePath.filename()).string());
 			}
 		}
 	}
@@ -155,8 +155,8 @@ HINSTANCE __stdcall NewLoadLibraryA(LPCSTR lpLibFileName)
 	{
 		//LocalizeStrings();
 		modulesRunning = true;
-		consoleModuleLoader.RunModules();
-		moduleLoader.RunModules();
+		consoleModuleLoader->RunModules();
+		moduleLoader->RunModules();
 	}
 
 	return result;

--- a/srcDLL/Globals.cpp
+++ b/srcDLL/Globals.cpp
@@ -1,11 +1,10 @@
 #include "Globals.h"
-#include "ConsoleArgumentParser.h"
 
 
 // Indicates if modules and Outpost 2 are running.
 // When set, attempting further initialization commands will cause errors.
 bool modulesRunning = false;
 
-std::unique_ptr<VolList> volList = std::make_unique<VolList>();
-std::unique_ptr<ConsoleModuleLoader> consoleModuleLoader = std::make_unique<ConsoleModuleLoader>(std::vector{FindModuleDirectory()});
-std::unique_ptr<ModuleLoader> moduleLoader = std::make_unique<ModuleLoader>();
+std::unique_ptr<VolList> volList;
+std::unique_ptr<ConsoleModuleLoader> consoleModuleLoader;
+std::unique_ptr<ModuleLoader> moduleLoader;

--- a/srcDLL/Globals.cpp
+++ b/srcDLL/Globals.cpp
@@ -6,6 +6,6 @@
 // When set, attempting further initialization commands will cause errors.
 bool modulesRunning = false;
 
-VolList volList;
-ConsoleModuleLoader consoleModuleLoader({FindModuleDirectory()});
-ModuleLoader moduleLoader;
+std::unique_ptr<VolList> volList = std::make_unique<VolList>();
+std::unique_ptr<ConsoleModuleLoader> consoleModuleLoader = std::make_unique<ConsoleModuleLoader>(std::vector{FindModuleDirectory()});
+std::unique_ptr<ModuleLoader> moduleLoader = std::make_unique<ModuleLoader>();

--- a/srcDLL/Globals.h
+++ b/srcDLL/Globals.h
@@ -3,9 +3,10 @@
 #include "VolList.h"
 #include "ConsoleModuleLoader.h"
 #include "ModuleLoader.h"
+#include <memory>
 
 
 extern bool modulesRunning;
-extern VolList volList;
-extern ConsoleModuleLoader consoleModuleLoader;
-extern ModuleLoader moduleLoader;
+extern std::unique_ptr<VolList> volList;
+extern std::unique_ptr<ConsoleModuleLoader> consoleModuleLoader;
+extern std::unique_ptr<ModuleLoader> moduleLoader;

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -33,9 +33,9 @@ OP2EXT_API size_t GetConsoleModDir_s(char* buffer, size_t bufferSize)
 {
 	// This is an older method that assumes only a single console module can be loaded
 	std::string consoleModuleDirectory;
-	if (consoleModuleLoader.Count() > 0) {
+	if (consoleModuleLoader->Count() > 0) {
 		// Assume they care about the first loaded console module
-		consoleModuleDirectory = consoleModuleLoader.GetModuleDirectory(0);
+		consoleModuleDirectory = consoleModuleLoader->GetModuleDirectory(0);
 	}
 	// Copy module directory to supplied buffer
 	return CopyStdStringIntoCharBuffer(consoleModuleDirectory + "\\", buffer, bufferSize);
@@ -56,9 +56,9 @@ OP2EXT_API char* GetCurrentModDir()
 {
 	// This is an older method that assumes only a single console module can be loaded
 	std::string modDirectory;
-	if (consoleModuleLoader.Count() > 0) {
+	if (consoleModuleLoader->Count() > 0) {
 		// Assume they care about the first loaded console module
-		modDirectory = consoleModuleLoader.GetModuleDirectory(0);
+		modDirectory = consoleModuleLoader->GetModuleDirectory(0);
 	}
 
 	if (modDirectory.empty()) {
@@ -77,7 +77,7 @@ OP2EXT_API void AddVolToList(const char* volFilename)
 		PostError("VOLs may not be added to the list after game startup.");
 	}
 	else {
-		volList.AddVolFile(volFilename);
+		volList->AddVolFile(volFilename);
 	}
 }
 
@@ -121,17 +121,17 @@ OP2EXT_API bool IsModuleLoaded(const char* moduleName)
 
 OP2EXT_API bool IsConsoleModuleLoaded(const char* moduleName)
 {
-	return consoleModuleLoader.IsModuleLoaded(moduleName);
+	return consoleModuleLoader->IsModuleLoaded(moduleName);
 }
 
 OP2EXT_API bool IsIniModuleLoaded(const char* moduleName)
 {
-	return moduleLoader.IsModuleLoaded(moduleName);
+	return moduleLoader->IsModuleLoaded(moduleName);
 }
 
 OP2EXT_API size_t GetLoadedModuleCount()
 {
-	return moduleLoader.Count() + consoleModuleLoader.Count();
+	return moduleLoader->Count() + consoleModuleLoader->Count();
 }
 
 OP2EXT_API size_t GetLoadedModuleName(size_t moduleIndex, char* buffer, size_t bufferSize)
@@ -141,11 +141,11 @@ OP2EXT_API size_t GetLoadedModuleName(size_t moduleIndex, char* buffer, size_t b
 	std::string moduleName;
 
 	try {
-		if (moduleIndex < moduleLoader.Count()) {
-			moduleName = moduleLoader.GetModuleName(moduleIndex);
+		if (moduleIndex < moduleLoader->Count()) {
+			moduleName = moduleLoader->GetModuleName(moduleIndex);
 		}
 		else if (moduleIndex < GetLoadedModuleCount()) {
-			moduleName = consoleModuleLoader.GetModuleName(moduleIndex - moduleLoader.Count());
+			moduleName = consoleModuleLoader->GetModuleName(moduleIndex - moduleLoader->Count());
 		}
 	}
 	catch (const std::exception& e) // Prevent throwing an error across DLL boundaries


### PR DESCRIPTION
This fixes #174. By replacing global objects with `unique_ptr` versions, construction can be delayed until `DllMain` has started, and yet the variable names are still visible as globals.
