### PR TITLE
Makefile updates

### DIFF
--- a/makefile-generic.mk
+++ b/makefile-generic.mk
@@ -52,7 +52,7 @@ CC = $($(config)_CC)
 
 # Variables to track dependencies
 DEPNAME = $(patsubst %.o,%.d,$@)
-DEPFLAGS = -MT $@ -MMD -MP -MF $(DEPNAME).temp
+DEPFLAGS = -MT $@ -MD -MP -MF $(DEPNAME).temp
 POSTCOMPILE = mv -f $(DEPNAME).temp $(DEPNAME) && touch $@
 
 # Variable to create missing output folders

--- a/makefile-generic.mk
+++ b/makefile-generic.mk
@@ -84,8 +84,8 @@ White := \e[0m
 	@$(MKDIR)
 	ar rcs "$@" $^
 
-# Rule to build intermediate project files
-%.o:
+# Rule to build intermediate files from C++
+%.cpp.o:
 	@$(MKDIR)
 	$(COMPILE.cpp)
 	@$(POSTCOMPILE)
@@ -154,7 +154,7 @@ $(1)_SRCDIR := $(dir $(3))
 
 # Project specific source files (directory scan), and associated object and dependency files
 $(1)_SRCS := $$(shell find $$($(1)_SRCFINDPATTERN) -name '*.cpp')
-$(1)_OBJS := $$(patsubst $$($(1)_SRCDIR)%.cpp,$$($(1)_INTDIR)%.o,$$($(1)_SRCS))
+$(1)_OBJS := $$(patsubst $$($(1)_SRCDIR)%,$$($(1)_INTDIR)%.o,$$($(1)_SRCS))
 $(1)_DEPS := $$(patsubst %.o,%.d,$$($(1)_OBJS))
 
 endef
@@ -191,7 +191,7 @@ $$($(1)_OUTPUT): $$($(1)_OBJS) $$($(1)_inputLibs)
 intermediate-$(1): $$($(1)_OBJS)
 
 # Object files depend on source and dependency files
-$$($(1)_OBJS): $$($(1)_INTDIR)%.o: $$($(1)_SRCDIR)%.cpp $$($(1)_INTDIR)%.d
+$$($(1)_OBJS): $$($(1)_INTDIR)%.o: $$($(1)_SRCDIR)% $$($(1)_INTDIR)%.d
 
 # Include all generated dependency info
 # (The `wildcard` will filter out files that don't exist to avoid warnings)


### PR DESCRIPTION
Linux only change.

This updated the generic `makefile` to add support for C and ASM source files (as opposed to just C++). In particular, the project declaration macros will now search for source files form these other languages, do an out of source tree build, track dependencies, and ensure output formats are matched up so everything links correctly.

This will help with the "CompatibilityTest.c" file in the "TestModule/" folder. It will also help with projects that contain Assembly language files. In particular, it may help with building OP2Internal (and NetFixClient) if copied to that project.
