### PR TITLE
Use string_view in CopyStdStringIntoCharBuffer

### DIFF
--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -26,7 +26,7 @@ int StubExt = 0;
 OP2EXT_API size_t GetGameDir_s(char* buffer, size_t bufferSize)
 {
 	// Adding "\\" to end of directory is required for backward compatibility.
-	return CopyStdStringIntoCharBuffer(GetGameDirectory() + "\\", buffer, bufferSize);
+	return CopyStringViewIntoCharBuffer(GetGameDirectory() + "\\", buffer, bufferSize);
 }
 
 OP2EXT_API size_t GetConsoleModDir_s(char* buffer, size_t bufferSize)
@@ -38,7 +38,7 @@ OP2EXT_API size_t GetConsoleModDir_s(char* buffer, size_t bufferSize)
 		consoleModuleDirectory = consoleModuleLoader.GetModuleDirectory(0);
 	}
 	// Copy module directory to supplied buffer
-	return CopyStdStringIntoCharBuffer(consoleModuleDirectory + "\\", buffer, bufferSize);
+	return CopyStringViewIntoCharBuffer(consoleModuleDirectory + "\\", buffer, bufferSize);
 }
 
 OP2EXT_API void GetGameDir(char* buffer)
@@ -154,5 +154,5 @@ OP2EXT_API size_t GetLoadedModuleName(size_t moduleIndex, char* buffer, size_t b
 			std::to_string(moduleIndex) + ". Details: " + std::string(e.what()));
 	}
 
-	return CopyStdStringIntoCharBuffer(moduleName, buffer, bufferSize);
+	return CopyStringViewIntoCharBuffer(moduleName, buffer, bufferSize);
 }

--- a/srcStatic/ResourceSearchPath.cpp
+++ b/srcStatic/ResourceSearchPath.cpp
@@ -79,7 +79,7 @@ bool ResManager::GetFilePath(const char* resourceName, /* [out] */ char* filePat
 		// Search for resource in module folder
 		const auto path = moduleDirectory + resourceName;
 		if (INVALID_FILE_ATTRIBUTES != GetFileAttributesA(path.c_str())) {
-			if (0 == CopyStdStringIntoCharBuffer(path, filePath, MAX_PATH)) {
+			if (0 == CopyStringViewIntoCharBuffer(path, filePath, MAX_PATH)) {
 				return true; // Resource found
 			} else {
 				Log("MAX_PATH exceeded while trying to return path to resource: " + std::string(resourceName));

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -37,7 +37,7 @@ std::wstring ConvertNarrowToWide(const std::string& inputString)
 }
 
 
-std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize)
+std::size_t CopyStringViewIntoCharBuffer(std::string_view stringToCopy, char* buffer, std::size_t bufferSize)
 {
 	// Precheck valid pointer and non-zero buffer size to avoid wrap around or null termination problems
 	if (buffer != nullptr && bufferSize > 0) {

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 #include <vector>
 #include <cstddef>
 
@@ -17,11 +18,11 @@ std::wstring WrapRawString(const wchar_t* str);
 std::string ConvertWideToNarrow(const std::wstring& inputWideString);
 std::wstring ConvertNarrowToWide(const std::string& inputNarrowString);
 
-// Copies a std::string to a raw character buffer
+// Copies a std::string_view into a raw character buffer
 // This is used to interface with C code
 // Returns 0 on success
 // Returns needed buffer size (including space for null terminator) if the destination buffer is too small
-std::size_t CopyStdStringIntoCharBuffer(const std::string& stringToCopy, char* buffer, std::size_t bufferSize);
+std::size_t CopyStringViewIntoCharBuffer(std::string_view stringToCopy, char* buffer, std::size_t bufferSize);
 
 // Converts all characters in string lower case
 std::string& ToLowerInPlace(std::string& x);

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -40,7 +40,7 @@ TEST(StringConversion, ConvertNarrowToWide)
 }
 
 
-TEST(StringConversion, CopyStdStringIntoCharBufferSafeNoOutputConditions)
+TEST(StringConversion, CopyStringViewIntoCharBufferSafeNoOutputConditions)
 {
 	constexpr char nonce = 'Z';
 	char buffer[8];
@@ -49,25 +49,25 @@ TEST(StringConversion, CopyStdStringIntoCharBufferSafeNoOutputConditions)
 	buffer[0] = nonce;
 
 	// Null buffer of size zero
-	EXPECT_EQ(1u, CopyStdStringIntoCharBuffer("", nullptr, 0));
+	EXPECT_EQ(1u, CopyStringViewIntoCharBuffer("", nullptr, 0));
 	EXPECT_EQ(nonce, buffer[0]);
-	EXPECT_EQ(2u, CopyStdStringIntoCharBuffer("A", nullptr, 0));
+	EXPECT_EQ(2u, CopyStringViewIntoCharBuffer("A", nullptr, 0));
 	EXPECT_EQ(nonce, buffer[0]);
 
 	// Null buffer with non-zero size
-	EXPECT_EQ(1u, CopyStdStringIntoCharBuffer("", nullptr, sizeof(buffer)));
+	EXPECT_EQ(1u, CopyStringViewIntoCharBuffer("", nullptr, sizeof(buffer)));
 	EXPECT_EQ(nonce, buffer[0]);
-	EXPECT_EQ(2u, CopyStdStringIntoCharBuffer("A", nullptr, sizeof(buffer)));
+	EXPECT_EQ(2u, CopyStringViewIntoCharBuffer("A", nullptr, sizeof(buffer)));
 	EXPECT_EQ(nonce, buffer[0]);
 
 	// Valid buffer but with size zero
-	EXPECT_EQ(1u, CopyStdStringIntoCharBuffer("", buffer, 0));
+	EXPECT_EQ(1u, CopyStringViewIntoCharBuffer("", buffer, 0));
 	EXPECT_EQ(nonce, buffer[0]);
-	EXPECT_EQ(2u, CopyStdStringIntoCharBuffer("A", buffer, 0));
+	EXPECT_EQ(2u, CopyStringViewIntoCharBuffer("A", buffer, 0));
 	EXPECT_EQ(nonce, buffer[0]);
 }
 
-TEST(StringConversion, CopyStdStringIntoCharBuffer)
+TEST(StringConversion, CopyStringViewIntoCharBuffer)
 {
 	constexpr char nonce = 'Z';
 	constexpr char null = '\0';
@@ -75,19 +75,19 @@ TEST(StringConversion, CopyStdStringIntoCharBuffer)
 
 	// Empty string (must still null terminate)
 	buffer[0] = nonce;
-	EXPECT_EQ(0u, CopyStdStringIntoCharBuffer("", buffer, sizeof(buffer)));
+	EXPECT_EQ(0u, CopyStringViewIntoCharBuffer("", buffer, sizeof(buffer)));
 	EXPECT_EQ(null, buffer[0]);
 	// Short string (extra buffer space to spare)
 	buffer[1] = nonce;
-	EXPECT_EQ(0u, CopyStdStringIntoCharBuffer("A", buffer, sizeof(buffer)));
+	EXPECT_EQ(0u, CopyStringViewIntoCharBuffer("A", buffer, sizeof(buffer)));
 	EXPECT_EQ(null, buffer[1]);
 	// Precise sized string (just enough room for null terminator)
 	buffer[7] = nonce;
-	EXPECT_EQ(0u, CopyStdStringIntoCharBuffer("1234567", buffer, sizeof(buffer)));
+	EXPECT_EQ(0u, CopyStringViewIntoCharBuffer("1234567", buffer, sizeof(buffer)));
 	EXPECT_EQ(null, buffer[7]);
 	// Overflow sized string (just barely no room for null terminator)
 	buffer[7] = nonce;
-	EXPECT_EQ(9u, CopyStdStringIntoCharBuffer("12345678", buffer, sizeof(buffer)));
+	EXPECT_EQ(9u, CopyStringViewIntoCharBuffer("12345678", buffer, sizeof(buffer)));
 	EXPECT_EQ(null, buffer[7]);
 }
 


### PR DESCRIPTION
I looked through the main libraries (not test code). This was the only string argument I thought was a good fit for string_view...