### PR TITLE
Add `IsDirectory` and `Exists`

### DIFF
--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -31,3 +31,11 @@ bool IsDirectory(const std::string& path)
 	auto modifiedPath = fs::path(path) / ".";
 	return fs::is_directory(modifiedPath);
 }
+
+bool Exists(const std::string& path)
+{
+	// Use a modified path to work around a Mingw bug
+	// With Mingw exists will return false for paths with a trailing slash
+	auto modifiedPath = fs::path(path) / ".";
+	return fs::exists(modifiedPath);
+}

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -22,3 +22,12 @@ std::string GetOutpost2IniSetting(const std::string& sectionName, const std::str
 {
 	return IniFile::GetValue(GetOutpost2IniPath(), sectionName, key);
 }
+
+
+bool IsDirectory(const std::string& path)
+{
+	// Use a modified path to work around a Mingw bug
+	// With Mingw is_directory will return false for paths with a trailing slash
+	auto modifiedPath = fs::path(path) / ".";
+	return fs::is_directory(modifiedPath);
+}

--- a/srcStatic/FileSystemHelper.h
+++ b/srcStatic/FileSystemHelper.h
@@ -16,3 +16,4 @@ std::string GetOutpost2IniPath();
 std::string GetOutpost2IniSetting(const std::string& sectionName, const std::string& key);
 
 bool IsDirectory(const std::string& path);
+bool Exists(const std::string& path);

--- a/srcStatic/FileSystemHelper.h
+++ b/srcStatic/FileSystemHelper.h
@@ -14,3 +14,5 @@ namespace fs = std::experimental::filesystem;
 std::string GetGameDirectory();
 std::string GetOutpost2IniPath();
 std::string GetOutpost2IniSetting(const std::string& sectionName, const std::string& key);
+
+bool IsDirectory(const std::string& path);

--- a/test/FileSystemHelper.test.cpp
+++ b/test/FileSystemHelper.test.cpp
@@ -27,3 +27,13 @@ TEST(FileSystemHelper, GetOutpost2IniSetting)
 	EXPECT_EQ("", GetOutpost2IniSetting("Game", "BadKey"));
 	EXPECT_EQ("", GetOutpost2IniSetting("BadSectionName", "BadKey"));
 }
+
+
+TEST(FileSystemHelper, IsDirectory)
+{
+	EXPECT_TRUE(IsDirectory("/"));
+	EXPECT_TRUE(IsDirectory("./"));
+
+	EXPECT_FALSE(IsDirectory("NonExistentPath"));
+	EXPECT_FALSE(IsDirectory("NonExistentPath/"));
+}

--- a/test/FileSystemHelper.test.cpp
+++ b/test/FileSystemHelper.test.cpp
@@ -37,3 +37,12 @@ TEST(FileSystemHelper, IsDirectory)
 	EXPECT_FALSE(IsDirectory("NonExistentPath"));
 	EXPECT_FALSE(IsDirectory("NonExistentPath/"));
 }
+
+TEST(FileSystemHelper, Exists)
+{
+	EXPECT_TRUE(Exists("/"));
+	EXPECT_TRUE(Exists("./"));
+
+	EXPECT_FALSE(Exists("NonExistentPath"));
+	EXPECT_FALSE(Exists("NonExistentPath/"));
+}


### PR DESCRIPTION
Add helper methods `IsDirectory` and `Exists`.

This both encapsulate workarounds for bugs in the Mingw implementation of the filesystem library. Using these methods helps insulate code from those bugs, and also insulates code from direct knowledge of the filesystem library.

This may help with a bug identified in PR #190.
