### PR TITLE
Workaround for Mingw code gen bug

### DIFF
--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -32,5 +32,25 @@ template <typename MethodPointerType>
 constexpr MethodPointerType GetMethodPointer(std::size_t methodAddress) {
 	static_assert(std::is_member_function_pointer_v<MethodPointerType>, "Type must be member function pointer");
 	auto methodVoidPointer = reinterpret_cast<void*>(methodAddress);
-	return reinterpret_cast<MethodPointerType&>(methodVoidPointer); // MSVC specific cast
+
+	// Need to handle a GCC/Mingw code generation bug
+	// Use a union to handle the thisOffset field which is left uninitialized by member function pointer casts
+	// MSVC will (in most cases) use a single field member function pointer as an optimization, so will be unaffected
+	union MethodPointerUnion {
+		MethodPointerType pointer;
+		struct {
+			std::size_t address;
+			std::size_t thisOffset;
+		};
+
+		MethodPointerUnion() : address(0), thisOffset(0) {} // The optimizer may actually skip this code, so assume no effect
+	} methodPointer;
+
+	// This cast works for a single field MSVC member function pointer
+	// For GCC/Mingw it leaves a hidden thisOffset field uninitialized
+	methodPointer.pointer = reinterpret_cast<MethodPointerType&>(methodVoidPointer); // MSVC specific cast
+	// Explicitly initialize hidden field
+	methodPointer.thisOffset = 0;
+
+	return methodPointer.pointer;
 }


### PR DESCRIPTION
Use a union to explicitly initialize the hidden `this` offset field of member function pointers.

GCC/Mingw always use at least a 2 field struct for member function pointers. MSVC can optimize it down to 1 field, given enough information about the class. This means the union can clear the extra hidden field for GCC/Mingw, but will leave MSVC optimized member function pointers untouched.

----

With this workaround, there are no longer any Linux crashes during shutdown, nor when the `/loadmod` command line option is used with a valid console module name.
