### PR TITLE
Rename `GetGameDirectory` to `GetExeDirectory`

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -130,7 +130,7 @@ for inclusion in Outpost 2. Does not recursively search subdirectories.
 */
 void LocateVolFiles(const std::string& relativeDirectory)
 {
-	const auto absoluteDirectory = fs::path(GetGameDirectory()) / fs::path(relativeDirectory);
+	const auto absoluteDirectory = fs::path(GetExeDirectory()) / fs::path(relativeDirectory);
 
 	// Append directory "." to work around Mingw bug with `is_directory`
 	if (!fs::is_directory(absoluteDirectory / ".")) {

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -26,7 +26,7 @@ int StubExt = 0;
 OP2EXT_API size_t GetGameDir_s(char* buffer, size_t bufferSize)
 {
 	// Adding "\\" to end of directory is required for backward compatibility.
-	return CopyStringViewIntoCharBuffer(GetGameDirectory() + "\\", buffer, bufferSize);
+	return CopyStringViewIntoCharBuffer(GetExeDirectory() + "\\", buffer, bufferSize);
 }
 
 OP2EXT_API size_t GetConsoleModDir_s(char* buffer, size_t bufferSize)
@@ -44,7 +44,7 @@ OP2EXT_API size_t GetConsoleModDir_s(char* buffer, size_t bufferSize)
 OP2EXT_API void GetGameDir(char* buffer)
 {
 	// Adding "\\" to end of directory is required for backward compatibility.
-	std::string gameDirectory = GetGameDirectory() + "\\";
+	std::string gameDirectory = GetExeDirectory() + "\\";
 
 	// Unable to use the newer funciton strcpy_s since we do not know the size of buffer,
 	// causing a security concern.

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -5,7 +5,7 @@
 #include <cstddef>
 
 
-std::string GetGameDirectory()
+std::string GetExeDirectory()
 {
 	char moduleFilename[MAX_PATH];
 	GetModuleFileNameA(nullptr, moduleFilename, MAX_PATH);
@@ -15,7 +15,7 @@ std::string GetGameDirectory()
 
 std::string GetOutpost2IniPath()
 {
-	return fs::path(GetGameDirectory()).append("outpost2.ini").string();
+	return fs::path(GetExeDirectory()).append("outpost2.ini").string();
 }
 
 std::string GetOutpost2IniSetting(const std::string& sectionName, const std::string& key)

--- a/srcStatic/FileSystemHelper.h
+++ b/srcStatic/FileSystemHelper.h
@@ -11,7 +11,7 @@ namespace fs = std::experimental::filesystem;
 #endif
 
 
-std::string GetGameDirectory();
+std::string GetExeDirectory();
 std::string GetOutpost2IniPath();
 std::string GetOutpost2IniSetting(const std::string& sectionName, const std::string& key);
 

--- a/srcStatic/GameModules/ConsoleModule.cpp
+++ b/srcStatic/GameModules/ConsoleModule.cpp
@@ -7,7 +7,7 @@
 
 ConsoleModule::ConsoleModule(const std::string& moduleName) : DllModule(moduleName)
 {
-	moduleDirectory = (fs::path(GetGameDirectory()) / moduleName).string() + "\\";
+	moduleDirectory = (fs::path(GetExeDirectory()) / moduleName).string() + "\\";
 
 	if (!IsDirectory(moduleDirectory)) {
 		throw std::runtime_error("Unable to access the provided module directory: " + 

--- a/srcStatic/LoggerFile.cpp
+++ b/srcStatic/LoggerFile.cpp
@@ -6,7 +6,7 @@
 
 
 LoggerFile::LoggerFile() :
-	logFile(GetGameDirectory() + "\\Outpost2Log.txt", std::ios::app | std::ios::out | std::ios::binary)
+	logFile(GetExeDirectory() + "\\Outpost2Log.txt", std::ios::app | std::ios::out | std::ios::binary)
 {
 	if (!logFile.is_open()) {
 		PostError("Unable to create or open Outpost2Log.txt");

--- a/test/ConsoleModule.test.cpp
+++ b/test/ConsoleModule.test.cpp
@@ -14,10 +14,10 @@ TEST(ConsoleModuleLoader, ModuleWithoutDLL)
 
 	// Test will need temporary module directory with no DLL present
 	// Ensure module directory ends with a trailing slash
-	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
+	const auto moduleDirectory = fs::path(GetExeDirectory()) / moduleName;
 	fs::create_directory(moduleDirectory);
 
-	const std::string iniFileName{ GetGameDirectory() + "TestIniFile.NonExistentData.ini" };
+	const std::string iniFileName{ GetExeDirectory() + "TestIniFile.NonExistentData.ini" };
 	IniFile iniFile(iniFileName);
 	ModuleLoader moduleLoader(iniFileName, {moduleName});
 	
@@ -46,7 +46,7 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 
 	// Test will need temporary module directory and invalid DLL file
 	// Ensure module directory ends with a trailing slash
-	const auto moduleDirectory = fs::path(GetGameDirectory()) / moduleName;
+	const auto moduleDirectory = fs::path(GetExeDirectory()) / moduleName;
 	const auto dllFile = moduleDirectory / "op2mod.dll";
 	
 	// Create temporary module directory
@@ -56,7 +56,7 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 	// Temporary object, immediately destructed, side effect creates file of size 0
 	std::ofstream(dllFile.string());
 
-	const std::string iniFileName{ GetGameDirectory() + "TestIniFile.NonExistentData.ini" };
+	const std::string iniFileName{ GetExeDirectory() + "TestIniFile.NonExistentData.ini" };
 	IniFile iniFile(iniFileName);
 	ModuleLoader moduleLoader(iniFileName, {moduleName});
 
@@ -85,7 +85,7 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 }
 
 TEST(ConsoleModuleLoader, MultiModule) {
-	const auto exeDir = fs::path(GetGameDirectory());
+	const auto exeDir = fs::path(GetExeDirectory());
 	const std::vector<std::string> moduleNames{"Module1", "Module2"};
 
 	// Create some empty test module directories
@@ -93,7 +93,7 @@ TEST(ConsoleModuleLoader, MultiModule) {
 		fs::create_directory(exeDir / moduleName);
 	}
 
-	const std::string iniFileName{ GetGameDirectory() + "TestIniFile.NonExistentData.ini" };
+	const std::string iniFileName{ GetExeDirectory() + "TestIniFile.NonExistentData.ini" };
 	IniFile iniFile(iniFileName);
 	ModuleLoader moduleLoader(iniFile, moduleNames);
 

--- a/test/FileSystemHelper.test.cpp
+++ b/test/FileSystemHelper.test.cpp
@@ -2,8 +2,8 @@
 #include <gtest/gtest.h>
 
 
-TEST(FileSystemHelper, GetGameDirectory) {
-	auto gameDirectory = fs::path(GetGameDirectory());
+TEST(FileSystemHelper, GetExeDirectory) {
+	auto gameDirectory = fs::path(GetExeDirectory());
 	// Work around MinGW failures for paths that end with a directory separator
 	gameDirectory += ".";
 	EXPECT_TRUE(gameDirectory.is_absolute()) << gameDirectory.string() + " is not an absolute path.";

--- a/test/IniFile.test.cpp
+++ b/test/IniFile.test.cpp
@@ -4,7 +4,7 @@
 
 
 TEST(IniFile, NonExistentDataRead) {
-	const std::string iniFileName{GetGameDirectory() + "TestIniFile.NonExistentData.ini"};
+	const std::string iniFileName{GetExeDirectory() + "TestIniFile.NonExistentData.ini"};
 	IniFile iniFile(iniFileName);
 
 	// Returns the full path
@@ -33,7 +33,7 @@ TEST(IniFile, NonExistentDataRead) {
 }
 
 TEST(IniFile, StaticMethodsWriteRead) {
-	const std::string iniFileName{GetGameDirectory() + "TestIniFile.StaticMethods.ini"};
+	const std::string iniFileName{GetExeDirectory() + "TestIniFile.StaticMethods.ini"};
 
 	// Initially no data
 	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName1"));
@@ -75,7 +75,7 @@ TEST(IniFile, StaticMethodsWriteRead) {
 }
 
 TEST(IniFile, IniFileWriteRead) {
-	const std::string iniFileName{GetGameDirectory() + "TestIniFile.WriteRead.ini"};
+	const std::string iniFileName{GetExeDirectory() + "TestIniFile.WriteRead.ini"};
 	IniFile iniFile(iniFileName);
 
 	// Initially no data
@@ -118,7 +118,7 @@ TEST(IniFile, IniFileWriteRead) {
 }
 
 TEST(IniFile, IniSectionWriteRead) {
-	const std::string iniFileName{GetGameDirectory() + "TestIniSection.WriteRead.ini"};
+	const std::string iniFileName{GetExeDirectory() + "TestIniSection.WriteRead.ini"};
 	IniSection iniSection(iniFileName, "SectionName");
 
 	// Initially no data

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 
 
-const fs::path logPath = fs::path(GetGameDirectory()).append("Outpost2Log.txt");
+const fs::path logPath = fs::path(GetExeDirectory()).append("Outpost2Log.txt");
 
 
 TEST(LoggerFile, LogFileExists)

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -20,7 +20,7 @@ int main(int argc, char** argv)
 
 void SetupIniFile()
 {
-	std::ofstream stream(fs::path(GetGameDirectory()).append("Outpost2.ini").string());
+	std::ofstream stream(fs::path(GetExeDirectory()).append("Outpost2.ini").string());
 	stream << "[Game]" << std::endl;
 	stream << "Music=1" << std::endl;
 	stream.close();


### PR DESCRIPTION
This closes #193.

When this method is called while the game is running, it returns the game folder. When it is called while unit tests are running, it returns the unit test executable folder.