### PR TITLE
Allow passing multiple console arguments into Outpost 2

### DIFF
--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -9,30 +9,33 @@
 std::vector<std::string> GetCommandLineArguments();
 std::string GetSwitch(std::vector<std::string>& arguments);
 std::string ParseSwitchName(std::string switchName);
-std::string ParseLoadModCommand(std::vector<std::string> arguments);
 
 
-std::string FindModuleDirectory()
+std::vector<std::string> FindModuleDirectories()
 {
 	try {
 		const auto arguments = GetCommandLineArguments();
-		return FindModuleDirectory(arguments);
+		return FindModuleDirectories(arguments);
 	} catch(const std::exception& e) {
 		PostError("Error parsing command line arguments: " + std::string(e.what()));
-		return std::string();
+		return {};
 	}
 }
 
-std::string FindModuleDirectory(std::vector<std::string> arguments)
+std::vector<std::string> FindModuleDirectories(std::vector<std::string> arguments)
 {
 	const std::string switchName = GetSwitch(arguments);
 
 	if (switchName.empty()) {
-		return std::string();
+		return {};
 	}
 
 	if (switchName == "loadmod") {
-		return ParseLoadModCommand(arguments);
+		if (arguments.empty()) {
+			throw std::runtime_error("No relative directory argument provided for the switch loadmod");
+		}
+
+		return arguments;
 	}
 
 	throw std::runtime_error("Provided switch is not supported: " + switchName);
@@ -62,17 +65,4 @@ std::string ParseSwitchName(std::string switchName)
 	ToLowerInPlace(switchName);
 
 	return switchName;
-}
-
-std::string ParseLoadModCommand(std::vector<std::string> arguments)
-{
-	if (arguments.empty()) {
-		throw std::runtime_error("No relative directory argument provided for the switch loadmod");
-	}
-
-	if (arguments.size() > 1) {
-		throw std::runtime_error("Too many arguments passed into switch LoadMod. If module relative directory contains spaces, surround the directory in quotes");
-	}
-
-	return arguments[0];
 }

--- a/srcStatic/ConsoleArgumentParser.h
+++ b/srcStatic/ConsoleArgumentParser.h
@@ -3,11 +3,11 @@
 #include <vector>
 #include <string>
 
-// Returns an empty string if no console switch is found or if the switch is ill-formed.
+// Returns an empty vector if no console switch is found or if the switch is ill-formed.
 // Logs error and posts modal dialog if switch is ill-formed.
 // Automatically pulls Console arguments using CommandLineToArgvW
-std::string FindModuleDirectory();
+std::vector<std::string> FindModuleDirectories();
 
 // Instead of pulling Console arguments, allows passing in arguments for testability
 // Passed in values should already be formatted as the return value of CommandLineToArgvW without the executable's name
-std::string FindModuleDirectory(std::vector<std::string> arguments);
+std::vector<std::string> FindModuleDirectories(std::vector<std::string> arguments);

--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -12,7 +12,7 @@
 
 
 ModuleLoader::ModuleLoader()
-	: iniFile(IniFile(GetOutpost2IniPath())), consoleModuleNames({ FindModuleDirectory() })
+	: iniFile(IniFile(GetOutpost2IniPath())), consoleModuleNames(FindModuleDirectories())
 {
 }
 

--- a/test/ConsoleArgumentParser.test.cpp
+++ b/test/ConsoleArgumentParser.test.cpp
@@ -5,30 +5,43 @@
 
 
 TEST(ConsoleArgumentParser, NoArgument) {
-	EXPECT_EQ("", FindModuleDirectory(std::vector<std::string> { }));
+	EXPECT_TRUE(FindModuleDirectories({ }).empty());
 }
 
 TEST(ConsoleArgumentParser, WellFormedNoSpaces)
 {
 	const std::string path("path");
-	EXPECT_EQ(path, FindModuleDirectory(std::vector<std::string> { "/loadmod", path }));
+	const auto directories = FindModuleDirectories({ "/loadmod", path });
+
+	EXPECT_EQ(1u, directories.size());
+	EXPECT_EQ(path, directories[0]);
 }
 
 TEST(ConsoleArgmunetParser, WellFormedSpaces)
 {
 	const std::string path("path with spaces");
-	EXPECT_EQ(path, FindModuleDirectory(std::vector<std::string> { "/loadmod", path }));
+	const auto directories = FindModuleDirectories({ "/loadmod", path });
+	
+	EXPECT_EQ(1u, directories.size());
+	EXPECT_EQ(path, directories[0]);
 }
 
 
 TEST(ConsoleArgumentParser, WrongSwitchName) {
-	EXPECT_THROW(FindModuleDirectory(std::vector<std::string> { "/WrongSwitch" }), std::runtime_error);
+	EXPECT_THROW(FindModuleDirectories({ "/WrongSwitch" }), std::runtime_error);
 }
 
 TEST(ConsoleArgumentParser, NoSwitchArgument) {
-	EXPECT_THROW(FindModuleDirectory(std::vector<std::string> { "/loadmod" }), std::runtime_error);
+	EXPECT_THROW(FindModuleDirectories({ "/loadmod" }), std::runtime_error);
 }
 
-TEST(ConsoleArgumentParser, TooManyArguments) {
-	EXPECT_THROW(FindModuleDirectory(std::vector<std::string> { "/loadmod", "path1", "path2" }), std::runtime_error);
+TEST(ConsoleArgumentParser, MultipleArguments) {
+	const std::string path1("path1");
+	const std::string path2("path2");
+
+	const auto directories = FindModuleDirectories({ "/loadmod", path1, path2 });
+
+	EXPECT_EQ(2u, directories.size());
+	EXPECT_EQ(path1, directories[0]);
+	EXPECT_EQ(path2, directories[1]);
 }


### PR DESCRIPTION
Tested by passing in both cm1 and TestModule. Both modules interacted with Outpost 2.

Significant changes to unit tests to accommodate.

Closes #184.