### PR TITLE
Isolate fs

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -130,10 +130,9 @@ for inclusion in Outpost 2. Does not recursively search subdirectories.
 */
 void LocateVolFiles(const std::string& relativeDirectory)
 {
-	const auto absoluteDirectory = fs::path(GetExeDirectory()) / fs::path(relativeDirectory);
+	const auto absoluteDirectory = (fs::path(GetExeDirectory()) / relativeDirectory).string();
 
-	// Append directory "." to work around Mingw bug with `is_directory`
-	if (!fs::is_directory(absoluteDirectory / ".")) {
+	if (!IsDirectory(absoluteDirectory)) {
 		return;
 	}
 

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -3,6 +3,7 @@
 #include "StringConversion.h"
 #include "OP2Memory.h"
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include "Log.h"
 #include "LoggerFile.h"
 #include "LoggerMessageBox.h"

--- a/srcStatic/ConsoleArgumentParser.cpp
+++ b/srcStatic/ConsoleArgumentParser.cpp
@@ -1,7 +1,6 @@
 #include "GetCommandLineArguments.h"
 #include "ConsoleArgumentParser.h"
 #include "StringConversion.h"
-#include "FileSystemHelper.h"
 #include "Log.h"
 #include <stdexcept>
 

--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -1,4 +1,5 @@
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include "IniFile.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/srcStatic/FileSystemHelper.h
+++ b/srcStatic/FileSystemHelper.h
@@ -2,14 +2,6 @@
 
 #include <string>
 
-#ifdef __cpp_lib_filesystem
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
-
 
 std::string GetExeDirectory();
 std::string GetOutpost2IniPath();

--- a/srcStatic/FsInclude.h
+++ b/srcStatic/FsInclude.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef __cpp_lib_filesystem
+#include <filesystem>
+namespace fs = std::filesystem;
+#else
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#endif

--- a/srcStatic/GameModules/ConsoleModule.cpp
+++ b/srcStatic/GameModules/ConsoleModule.cpp
@@ -15,7 +15,7 @@ ConsoleModule::ConsoleModule(const std::string& moduleName) : DllModule(moduleNa
 	}
 
 	const auto dllPath = fs::path(moduleDirectory).append("op2mod.dll").string();
-	if (!fs::exists(dllPath)) {
+	if (!Exists(dllPath)) {
 		return; // Some console modules do not contain dlls
 	}
 

--- a/srcStatic/GameModules/ConsoleModule.cpp
+++ b/srcStatic/GameModules/ConsoleModule.cpp
@@ -1,5 +1,6 @@
 #include "ConsoleModule.h"
 #include "../FileSystemHelper.h"
+#include "../FsInclude.h"
 #include "../Log.h"
 #include "../WindowsErrorCode.h"
 #include <windows.h>

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -1,7 +1,6 @@
 #include "Log.h"
 #include "Logger.h"
 #include "LoggerMessageBox.h"
-#include "FileSystemHelper.h"
 #include "FsInclude.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>

--- a/srcStatic/Log.cpp
+++ b/srcStatic/Log.cpp
@@ -2,6 +2,7 @@
 #include "Logger.h"
 #include "LoggerMessageBox.h"
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -154,6 +154,7 @@
     <ClInclude Include="GetCommandLineArguments.h" />
     <ClInclude Include="ConsoleArgumentParser.h" />
     <ClInclude Include="FileSystemHelper.h" />
+    <ClInclude Include="FsInclude.h" />
     <ClInclude Include="GameModule.h" />
     <ClInclude Include="GameModules\IniModule.h" />
     <ClInclude Include="ModuleLoader.h" />

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -32,6 +32,7 @@
     <ClInclude Include="GetCommandLineArguments.h" />
     <ClInclude Include="ConsoleArgumentParser.h" />
     <ClInclude Include="FileSystemHelper.h" />
+    <ClInclude Include="FsInclude.h" />
     <ClInclude Include="GameModule.h" />
     <ClInclude Include="ModuleLoader.h" />
     <ClInclude Include="IniFile.h" />

--- a/test/ConsoleModule.test.cpp
+++ b/test/ConsoleModule.test.cpp
@@ -86,12 +86,12 @@ TEST(ConsoleModuleLoader, ModuleWithEmptyDLL)
 }
 
 TEST(ConsoleModuleLoader, MultiModule) {
-	const auto exeDir = fs::path(GetExeDirectory());
+	const auto exeDirectory = fs::path(GetExeDirectory());
 	const std::vector<std::string> moduleNames{"Module1", "Module2"};
 
 	// Create some empty test module directories
 	for (const auto& moduleName : moduleNames) {
-		fs::create_directory(exeDir / moduleName);
+		fs::create_directory(exeDirectory / moduleName);
 	}
 
 	const std::string iniFileName{ GetExeDirectory() + "TestIniFile.NonExistentData.ini" };
@@ -115,6 +115,6 @@ TEST(ConsoleModuleLoader, MultiModule) {
 	// Cleanup test module directories
 	for (const auto& moduleName : moduleNames) {
 		// Use Win API directly since fs::remove doesn't work under Mingw
-		EXPECT_NE(0, RemoveDirectoryW((exeDir / moduleName).wstring().c_str()));
+		EXPECT_NE(0, RemoveDirectoryW((exeDirectory / moduleName).wstring().c_str()));
 	}
 }

--- a/test/ConsoleModule.test.cpp
+++ b/test/ConsoleModule.test.cpp
@@ -1,5 +1,6 @@
 #include "ModuleLoader.h"
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include "IniFile.h"
 #include <windows.h>
 #include <gtest/gtest.h>

--- a/test/FileSystemHelper.test.cpp
+++ b/test/FileSystemHelper.test.cpp
@@ -4,11 +4,10 @@
 
 TEST(FileSystemHelper, GetExeDirectory) {
 	auto gameDirectory = fs::path(GetExeDirectory());
-	// Work around MinGW failures for paths that end with a directory separator
-	gameDirectory += ".";
-	EXPECT_TRUE(gameDirectory.is_absolute()) << gameDirectory.string() + " is not an absolute path.";
-	EXPECT_TRUE(fs::exists(gameDirectory)) << gameDirectory.string() + " does not exist on filesystem.";
-	EXPECT_TRUE(fs::is_directory(gameDirectory)) << gameDirectory.string() + " is not a directory.";
+	auto gameDirectoryString = gameDirectory.string();
+	EXPECT_TRUE(gameDirectory.is_absolute()) << gameDirectoryString + " is not an absolute path.";
+	EXPECT_TRUE(Exists(gameDirectoryString)) << gameDirectoryString + " does not exist on filesystem.";
+	EXPECT_TRUE(IsDirectory(gameDirectoryString)) << gameDirectoryString + " is not a directory.";
 }
 
 TEST(FileSystemHelper, GetOutpost2IniPath) {

--- a/test/FileSystemHelper.test.cpp
+++ b/test/FileSystemHelper.test.cpp
@@ -4,11 +4,11 @@
 
 
 TEST(FileSystemHelper, GetExeDirectory) {
-	auto gameDirectory = fs::path(GetExeDirectory());
-	auto gameDirectoryString = gameDirectory.string();
-	EXPECT_TRUE(gameDirectory.is_absolute()) << gameDirectoryString + " is not an absolute path.";
-	EXPECT_TRUE(Exists(gameDirectoryString)) << gameDirectoryString + " does not exist on filesystem.";
-	EXPECT_TRUE(IsDirectory(gameDirectoryString)) << gameDirectoryString + " is not a directory.";
+	auto exeDirectory = fs::path(GetExeDirectory());
+	auto exeDirectoryString = exeDirectory.string();
+	EXPECT_TRUE(exeDirectory.is_absolute()) << exeDirectoryString + " is not an absolute path.";
+	EXPECT_TRUE(Exists(exeDirectoryString)) << exeDirectoryString + " does not exist on filesystem.";
+	EXPECT_TRUE(IsDirectory(exeDirectoryString)) << exeDirectoryString + " is not a directory.";
 }
 
 TEST(FileSystemHelper, GetOutpost2IniPath) {

--- a/test/FileSystemHelper.test.cpp
+++ b/test/FileSystemHelper.test.cpp
@@ -1,4 +1,5 @@
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include <gtest/gtest.h>
 
 

--- a/test/IniFile.test.cpp
+++ b/test/IniFile.test.cpp
@@ -1,5 +1,6 @@
 #include "IniFile.h"
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include <gtest/gtest.h>
 
 

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -1,5 +1,6 @@
 #include "LoggerFile.h"
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include <gtest/gtest.h>
 
 

--- a/test/LoggerFile.test.cpp
+++ b/test/LoggerFile.test.cpp
@@ -3,14 +3,14 @@
 #include <gtest/gtest.h>
 
 
-const fs::path logPath = fs::path(GetExeDirectory()).append("Outpost2Log.txt");
+const auto logPath = fs::path(GetExeDirectory()).append("Outpost2Log.txt").string();
 
 
 TEST(LoggerFile, LogFileExists)
 {
 	// Creating a logger should open or create a log file
 	LoggerFile logger;
-	ASSERT_TRUE(fs::exists(logPath));
+	ASSERT_TRUE(Exists(logPath));
 }
 
 TEST(LoggerFile, MessageLogged)

--- a/test/Main.cpp
+++ b/test/Main.cpp
@@ -1,4 +1,5 @@
 #include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include "OP2Memory.h"
 #include "Log.h"
 #include <gtest/gtest.h>


### PR DESCRIPTION
After much though, I think this is sufficient to close #192.

It doesn't go all the way of wrapping all `fs::` access, but does wrap problem functions, and separates `<filesystem>` include from inclusion of other methods.
