### PR TITLE
Load ini modules via ini section

### DIFF
--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -91,7 +91,7 @@ bool ModuleLoader::IsModuleRequested(const std::string& sectionName, const std::
 		return false;
 	}
 
-	PostError("Module named " + moduleName + " contains an innapropriate setting. It must be set to Yes or No");
+	PostError("Module named " + moduleName + " contains an innapropriate setting of " + isModuleRequested + ". It must be set to Yes or No");
 	return false;
 }
 

--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -25,7 +25,7 @@ ModuleLoader::ModuleLoader(IniFile iniFile, std::vector<std::string> consoleModu
 
 void ModuleLoader::RegisterBuiltInModules()
 {
-	if (IsBuiltInModuleRequested("IPDropDown")) {
+	if (IsModuleRequested("BuiltInModules", "IPDropDown")) {
 		RegisterModule(std::make_unique<IPDropDown>());
 	}
 }
@@ -80,9 +80,9 @@ void ModuleLoader::RegisterIniModules()
 	}
 }
 
-bool ModuleLoader::IsBuiltInModuleRequested(const std::string& moduleName)
+bool ModuleLoader::IsModuleRequested(const std::string& sectionName, const std::string& moduleName)
 {
-	const auto isModuleRequested = ToLower(iniFile.GetValue("BuiltInModules", moduleName));
+	const auto isModuleRequested = ToLower(iniFile.GetValue(sectionName, moduleName));
 
 	if (isModuleRequested == "yes") {
 		return true;
@@ -91,7 +91,7 @@ bool ModuleLoader::IsBuiltInModuleRequested(const std::string& moduleName)
 		return false;
 	}
 
-	PostError("Built-in module named " + moduleName + " contains an innapropriate setting. It must be set to Yes or No");
+	PostError("Module named " + moduleName + " contains an innapropriate setting. It must be set to Yes or No");
 	return false;
 }
 

--- a/srcStatic/ModuleLoader.cpp
+++ b/srcStatic/ModuleLoader.cpp
@@ -67,15 +67,16 @@ void ModuleLoader::RegisterConsoleModules()
 
 void ModuleLoader::RegisterIniModules()
 {
-	const auto sectionNames = GetModuleNames("ExternalModules");
-
-	for (const auto& sectionName : sectionNames)
+	for (const auto moduleName : iniFile.GetKeyNames("ExternalModules"))
 	{
-		try {
-			RegisterModule(std::make_unique<IniModule>(iniFile[sectionName]));
-		}
-		catch (const std::exception& e) {
-			PostError("Unable to load ini module " + sectionName + ". " + e.what());
+		if (IsModuleRequested("ExternalModules", moduleName)) 
+		{
+			try {
+				RegisterModule(std::make_unique<IniModule>(iniFile[moduleName]));
+			}
+			catch (const std::exception& e) {
+				PostError("Unable to load ini module " + moduleName + ". " + e.what());
+			}
 		}
 	}
 }
@@ -93,14 +94,6 @@ bool ModuleLoader::IsModuleRequested(const std::string& sectionName, const std::
 
 	PostError("Module named " + moduleName + " contains an innapropriate setting of " + isModuleRequested + ". It must be set to Yes or No");
 	return false;
-}
-
-std::vector<std::string> ModuleLoader::GetModuleNames(const std::string& moduleType)
-{
-	auto sectionNamesString = iniFile.GetValue("Game", moduleType);
-	auto sectionNames = ParseCsv(sectionNamesString);
-
-	return sectionNames;
 }
 
 // An INI module name is the SectionName from the INI file with its config settings

--- a/srcStatic/ModuleLoader.h
+++ b/srcStatic/ModuleLoader.h
@@ -34,6 +34,6 @@ private:
 	// Console module names are the relative path from the game folder (no trailing slash)
 	void RegisterConsoleModules();
 	void RegisterIniModules();
-	bool IsBuiltInModuleRequested(const std::string& moduleName);
+	bool IsModuleRequested(const std::string& sectionName, const std::string& moduleName);
 	std::vector<std::string> GetModuleNames(const std::string& moduleType);
 };

--- a/srcStatic/ModuleLoader.h
+++ b/srcStatic/ModuleLoader.h
@@ -35,5 +35,4 @@ private:
 	void RegisterConsoleModules();
 	void RegisterIniModules();
 	bool IsModuleRequested(const std::string& sectionName, const std::string& moduleName);
-	std::vector<std::string> GetModuleNames(const std::string& moduleType);
 };

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -9,7 +9,7 @@
 
 
 // sectionPairs is a non-line terminated list of keys and values. EG: TestModule = No
-void WriteExternalModuleIniFile(std::string_view iniFilename, const std::vector<std::string_view> sectionPairs)
+void WriteExternalModuleIniFile(const std::string& iniFilename, const std::vector<std::string_view> sectionPairs)
 {
 	std::ofstream iniFileStream(iniFilename);
 

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -1,0 +1,53 @@
+#include "FileSystemHelper.h"
+#include "FsInclude.h"
+#include "IniFile.h"
+#include "ModuleLoader.h"
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <gtest/gtest.h>
+
+
+// sectionPairs is a non-line terminated list of keys and values. EG: TestModule = No
+void WriteExternalModuleIniFile(std::string_view iniFilename, const std::vector<std::string_view> sectionPairs)
+{
+	std::ofstream iniFileStream(iniFilename);
+
+	iniFileStream << "[ExternalModules]\n";
+
+	for (const auto& sectionPair : sectionPairs)
+	{
+		iniFileStream << sectionPair << "\n";
+		//iniFileStream << "Test = yes\n";
+	}
+
+	iniFileStream.close();
+}
+
+TEST(IniModule, NoDll)
+{
+	const auto iniFilename = fs::path(GetExeDirectory()) / fs::path("IniModuleTest.ini");
+	WriteExternalModuleIniFile(iniFilename.string(), { "Test = yes" });
+
+	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
+
+	// No DLL found. An error should post, but program continues to run 
+	EXPECT_NO_THROW(moduleLoader.LoadModules());
+	EXPECT_EQ(0u, moduleLoader.Count());
+
+	fs::remove(iniFilename);
+}
+
+TEST(IniModule, InappropriateValue)
+{
+	const auto iniFilename = fs::path(GetExeDirectory()) / fs::path("IniModuleTest.ini");
+	WriteExternalModuleIniFile(iniFilename.string(), { "Test = InappropriateValue" });
+
+	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
+
+	// Inappropriate value for if module should be loaded. An error should post, but program continues to run 
+	EXPECT_NO_THROW(moduleLoader.LoadModules());
+	EXPECT_EQ(0u, moduleLoader.Count());
+
+	fs::remove(iniFilename);
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="ConsoleModule.test.cpp" />
     <ClCompile Include="FileSystemHelper.test.cpp" />
     <ClCompile Include="IniFile.test.cpp" />
+    <ClCompile Include="IniModule.test.cpp" />
     <ClCompile Include="Log.test.cpp" />
     <ClCompile Include="ModuleLoader.test.cpp" />
     <ClCompile Include="LoggerFile.test.cpp" />


### PR DESCRIPTION
Closes #139.
Partially addresses #76.

The different tests for ModuleLoader and modules are spread across 3 test files now. I think it is good we are separating them out, but maybe some thought should be placed into which tests are run in which file to prevent duplicating work and easing organization. Maybe better for a separate branch?