### PR TITLE
Convert log message tests to use `LoggerMock`

### DIFF
--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -17,9 +17,9 @@ protected:
 	}
 
 	// sectionPairs is a non-line terminated list of keys and values. EG: TestModule = No
-	void WriteExternalModuleIniFile(const std::string& iniFilename, const std::vector<std::string_view> sectionPairs)
+	void WriteExternalModuleIniFile(const std::vector<std::string_view> sectionPairs)
 	{
-		std::ofstream iniFileStream(iniFilename);
+		std::ofstream iniFileStream(iniFilename.string());
 
 		iniFileStream << "[ExternalModules]" << std::endl;
 		for (const auto& sectionPair : sectionPairs) {
@@ -33,7 +33,7 @@ protected:
 
 TEST_F(IniModuleTest, NoDll)
 {
-	WriteExternalModuleIniFile(iniFilename.string(), { "Test = yes" });
+	WriteExternalModuleIniFile({ "Test = yes" });
 
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
@@ -45,7 +45,7 @@ TEST_F(IniModuleTest, NoDll)
 
 TEST_F(IniModuleTest, InappropriateValue)
 {
-	WriteExternalModuleIniFile(iniFilename.string(), { "Test = InappropriateValue" });
+	WriteExternalModuleIniFile({ "Test = InappropriateValue" });
 
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -38,8 +38,7 @@ TEST_F(IniModuleTest, NoDll)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// No DLL found. An error should post, but program continues to run 
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
-	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("Unable to load dll for module"), "op2ext.dll")).Times(1);
+	ExpectErrorLogCall("Unable to load dll for module", 1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
 }
@@ -51,8 +50,7 @@ TEST_F(IniModuleTest, InappropriateValue)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// Inappropriate value for if module should be loaded. An error should post, but program continues to run 
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
-	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("contains an innapropriate setting of"), "op2ext.dll")).Times(1);
+	ExpectErrorLogCall("contains an innapropriate setting of", 1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
 }

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -16,24 +16,20 @@ protected:
 		LogMessageTest::TearDown();
 	}
 
+	// sectionPairs is a non-line terminated list of keys and values. EG: TestModule = No
+	void WriteExternalModuleIniFile(const std::string& iniFilename, const std::vector<std::string_view> sectionPairs)
+	{
+		std::ofstream iniFileStream(iniFilename);
+
+		iniFileStream << "[ExternalModules]" << std::endl;
+		for (const auto& sectionPair : sectionPairs) {
+			iniFileStream << sectionPair << std::endl;
+		}
+	}
+
 	const fs::path iniFilename = fs::path(GetExeDirectory()) / fs::path("IniModuleTest.ini");
 };
 
-
-// sectionPairs is a non-line terminated list of keys and values. EG: TestModule = No
-void WriteExternalModuleIniFile(const std::string& iniFilename, const std::vector<std::string_view> sectionPairs)
-{
-	std::ofstream iniFileStream(iniFilename);
-
-	iniFileStream << "[ExternalModules]" << std::endl;
-
-	for (const auto& sectionPair : sectionPairs)
-	{
-		iniFileStream << sectionPair << std::endl;
-	}
-
-	iniFileStream.close();
-}
 
 TEST_F(IniModuleTest, NoDll)
 {

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -10,6 +10,8 @@
 
 
 class IniModuleTest : public LogMessageTest {
+protected:
+	const fs::path iniFilename = fs::path(GetExeDirectory()) / fs::path("IniModuleTest.ini");
 };
 
 
@@ -30,7 +32,6 @@ void WriteExternalModuleIniFile(const std::string& iniFilename, const std::vecto
 
 TEST_F(IniModuleTest, NoDll)
 {
-	const auto iniFilename = fs::path(GetExeDirectory()) / fs::path("IniModuleTest.ini");
 	WriteExternalModuleIniFile(iniFilename.string(), { "Test = yes" });
 
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
@@ -46,7 +47,6 @@ TEST_F(IniModuleTest, NoDll)
 
 TEST_F(IniModuleTest, InappropriateValue)
 {
-	const auto iniFilename = fs::path(GetExeDirectory()) / fs::path("IniModuleTest.ini");
 	WriteExternalModuleIniFile(iniFilename.string(), { "Test = InappropriateValue" });
 
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -38,7 +38,6 @@ TEST_F(IniModuleTest, NoDll)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// No DLL found. An error should post, but program continues to run 
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
 	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("Unable to load dll for module"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
@@ -51,7 +50,6 @@ TEST_F(IniModuleTest, InappropriateValue)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// Inappropriate value for if module should be loaded. An error should post, but program continues to run 
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
 	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("contains an innapropriate setting of"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -11,6 +11,11 @@
 
 class IniModuleTest : public LogMessageTest {
 protected:
+	void TearDown() {
+		fs::remove(iniFilename);
+		LogMessageTest::TearDown();
+	}
+
 	const fs::path iniFilename = fs::path(GetExeDirectory()) / fs::path("IniModuleTest.ini");
 };
 
@@ -40,9 +45,6 @@ TEST_F(IniModuleTest, NoDll)
 	EXPECT_CALL(logger, Log(::testing::HasSubstr("Unable to load dll for module"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
-
-
-	fs::remove(iniFilename);
 }
 
 TEST_F(IniModuleTest, InappropriateValue)
@@ -55,7 +57,4 @@ TEST_F(IniModuleTest, InappropriateValue)
 	EXPECT_CALL(logger, Log(::testing::HasSubstr("contains an innapropriate setting of"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
-
-
-	fs::remove(iniFilename);
 }

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -38,6 +38,7 @@ TEST_F(IniModuleTest, NoDll)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// No DLL found. An error should post, but program continues to run 
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
 	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("Unable to load dll for module"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
@@ -50,6 +51,7 @@ TEST_F(IniModuleTest, InappropriateValue)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// Inappropriate value for if module should be loaded. An error should post, but program continues to run 
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
 	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("contains an innapropriate setting of"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -38,7 +38,8 @@ TEST_F(IniModuleTest, NoDll)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// No DLL found. An error should post, but program continues to run 
-	ExpectErrorLogCall("Unable to load dll for module", 1);
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
+	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("Unable to load dll for module"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
 }
@@ -50,7 +51,8 @@ TEST_F(IniModuleTest, InappropriateValue)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// Inappropriate value for if module should be loaded. An error should post, but program continues to run 
-	ExpectErrorLogCall("contains an innapropriate setting of", 1);
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
+	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("contains an innapropriate setting of"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
 }

--- a/test/IniModule.test.cpp
+++ b/test/IniModule.test.cpp
@@ -38,7 +38,7 @@ TEST_F(IniModuleTest, NoDll)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// No DLL found. An error should post, but program continues to run 
-	EXPECT_CALL(logger, Log(::testing::HasSubstr("Unable to load dll for module"), "op2ext.dll")).Times(1);
+	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("Unable to load dll for module"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
 }
@@ -50,7 +50,7 @@ TEST_F(IniModuleTest, InappropriateValue)
 	ModuleLoader moduleLoader(IniFile(iniFilename.string()), {});
 
 	// Inappropriate value for if module should be loaded. An error should post, but program continues to run 
-	EXPECT_CALL(logger, Log(::testing::HasSubstr("contains an innapropriate setting of"), "op2ext.dll")).Times(1);
+	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("contains an innapropriate setting of"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.LoadModules());
 	EXPECT_EQ(0u, moduleLoader.Count());
 }

--- a/test/Log.test.cpp
+++ b/test/Log.test.cpp
@@ -15,4 +15,3 @@ TEST_F(LogMessageTest, ActiveLoggerReceivesMessages) {
 	EXPECT_CALL(logger, Log(message, "op2ext.dll"));
 	EXPECT_NO_THROW(Log(message));
 }
-

--- a/test/LogMessageTest.cpp
+++ b/test/LogMessageTest.cpp
@@ -13,9 +13,11 @@ LoggerMock::~LoggerMock() {}
 void LogMessageTest::SetUp() {
 	// Install test logger
 	EXPECT_NO_THROW(SetLogger(&logger));
+	EXPECT_NO_THROW(SetLoggerError(&loggerError));
 }
 
 void LogMessageTest::TearDown() {
 	// Remove test logger
 	EXPECT_NO_THROW(SetLogger(nullptr));
+	EXPECT_NO_THROW(SetLoggerError(nullptr));
 }

--- a/test/LogMessageTest.h
+++ b/test/LogMessageTest.h
@@ -19,4 +19,22 @@ protected:
 
 	LoggerMock logger;
 	LoggerMock loggerError;
+
+	void ExpectNoLogCall()
+	{
+		EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
+		EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
+	}
+
+	void ExpectLogCall(const std::string& substring, int times)
+	{
+		EXPECT_CALL(logger, Log(::testing::HasSubstr(substring), "op2ext.dll")).Times(1);
+		EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
+	}
+
+	void ExpectErrorLogCall(const std::string& substring, int times)
+	{
+		EXPECT_CALL(logger, Log(::testing::HasSubstr(substring), "op2ext.dll")).Times(1);
+		EXPECT_CALL(loggerError, Log(::testing::HasSubstr(substring), "op2ext.dll")).Times(1);
+	}
 };

--- a/test/LogMessageTest.h
+++ b/test/LogMessageTest.h
@@ -19,22 +19,4 @@ protected:
 
 	LoggerMock logger;
 	LoggerMock loggerError;
-
-	void ExpectNoLogCall()
-	{
-		EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
-		EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
-	}
-
-	void ExpectLogCall(const std::string& substring, int times)
-	{
-		EXPECT_CALL(logger, Log(::testing::HasSubstr(substring), "op2ext.dll")).Times(1);
-		EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
-	}
-
-	void ExpectErrorLogCall(const std::string& substring, int times)
-	{
-		EXPECT_CALL(logger, Log(::testing::HasSubstr(substring), "op2ext.dll")).Times(1);
-		EXPECT_CALL(loggerError, Log(::testing::HasSubstr(substring), "op2ext.dll")).Times(1);
-	}
 };

--- a/test/LogMessageTest.h
+++ b/test/LogMessageTest.h
@@ -18,4 +18,5 @@ protected:
 	void TearDown() override;
 
 	LoggerMock logger;
+	LoggerMock loggerError;
 };

--- a/test/ModuleLoader.test.cpp
+++ b/test/ModuleLoader.test.cpp
@@ -71,13 +71,11 @@ TEST_F(ModuleLoaderTest, RejectCaseInsensitiveDuplicateNames)
 {
 	ModuleLoader moduleLoader;
 
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
 	EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("TestModule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 
 	// Ensure ModuleManager does not allow multiple modules with same name but different casing
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
 	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("You may not add a module with an existing name"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("testmodule")));
 	EXPECT_EQ(1u, moduleLoader.Count());

--- a/test/ModuleLoader.test.cpp
+++ b/test/ModuleLoader.test.cpp
@@ -71,12 +71,14 @@ TEST_F(ModuleLoaderTest, RejectCaseInsensitiveDuplicateNames)
 {
 	ModuleLoader moduleLoader;
 
-	ExpectNoLogCall();
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
+	EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("TestModule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 
 	// Ensure ModuleManager does not allow multiple modules with same name but different casing
-	ExpectErrorLogCall("You may not add a module with an existing name", 1);
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
+	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("You may not add a module with an existing name"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("testmodule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 }

--- a/test/ModuleLoader.test.cpp
+++ b/test/ModuleLoader.test.cpp
@@ -71,12 +71,12 @@ TEST_F(ModuleLoaderTest, RejectCaseInsensitiveDuplicateNames)
 {
 	ModuleLoader moduleLoader;
 
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
+	EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("TestModule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 
 	// Ensure ModuleManager does not allow multiple modules with same name but different casing
-	EXPECT_CALL(logger, Log(::testing::HasSubstr("You may not add a module with an existing name"), "op2ext.dll")).Times(1);
+	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("You may not add a module with an existing name"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("testmodule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 }

--- a/test/ModuleLoader.test.cpp
+++ b/test/ModuleLoader.test.cpp
@@ -71,11 +71,13 @@ TEST_F(ModuleLoaderTest, RejectCaseInsensitiveDuplicateNames)
 {
 	ModuleLoader moduleLoader;
 
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
 	EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("TestModule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 
 	// Ensure ModuleManager does not allow multiple modules with same name but different casing
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
 	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("You may not add a module with an existing name"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("testmodule")));
 	EXPECT_EQ(1u, moduleLoader.Count());

--- a/test/ModuleLoader.test.cpp
+++ b/test/ModuleLoader.test.cpp
@@ -1,10 +1,14 @@
 #include "GameModules/IpDropDown.h"
 #include "GameModules/IniModule.h"
 #include "ModuleLoader.h"
-#include "TestLog.h"
+#include "LogMessageTest.h"
 #include <gtest/gtest.h>
 #include <memory>
 #include <stdexcept>
+
+
+class ModuleLoaderTest : public LogMessageTest {
+};
 
 
 // Use to test that two modules with the same name but different casing is rejected from registering with the ModuleLoader
@@ -63,20 +67,16 @@ TEST(ModuleLoader, BuiltInModulePassed)
 	EXPECT_NO_THROW(moduleLoader.UnloadModules());
 }
 
-TEST(ModuleLoader, RejectCaseInsensitiveDuplicateNames)
+TEST_F(ModuleLoaderTest, RejectCaseInsensitiveDuplicateNames)
 {
-	ResetTestLog();
-
 	ModuleLoader moduleLoader;
 
+	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("TestModule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
-	EXPECT_EQ(0u, GetErrorLogger().Count());
 
 	// Ensure ModuleManager does not allow multiple modules with same name but different casing
+	EXPECT_CALL(logger, Log(::testing::HasSubstr("You may not add a module with an existing name"), "op2ext.dll")).Times(1);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("testmodule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
-
-	EXPECT_EQ(1u, GetErrorLogger().Count());
-	EXPECT_TRUE(GetErrorLogger().Pop("You may not add a module with an existing name"));
 }

--- a/test/ModuleLoader.test.cpp
+++ b/test/ModuleLoader.test.cpp
@@ -71,14 +71,12 @@ TEST_F(ModuleLoaderTest, RejectCaseInsensitiveDuplicateNames)
 {
 	ModuleLoader moduleLoader;
 
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(0);
-	EXPECT_CALL(loggerError, Log(::testing::_, ::testing::_)).Times(0);
+	ExpectNoLogCall();
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("TestModule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 
 	// Ensure ModuleManager does not allow multiple modules with same name but different casing
-	EXPECT_CALL(logger, Log(::testing::_, ::testing::_)).Times(1);
-	EXPECT_CALL(loggerError, Log(::testing::HasSubstr("You may not add a module with an existing name"), "op2ext.dll")).Times(1);
+	ExpectErrorLogCall("You may not add a module with an existing name", 1);
 	EXPECT_NO_THROW(moduleLoader.RegisterModule(std::make_unique<DifferentCasedNameModule>("testmodule")));
 	EXPECT_EQ(1u, moduleLoader.Count());
 }


### PR DESCRIPTION
Based on PR #213, and set to merge there.

A few notes:
- I added an empty test fixture class that inherits from `LogMessageTest`. This is simply to give a better name to the test in the `TEST_F` macro, and allow for better grouping.
- The `EXPECT_CALL` must be set before the expected call is triggered.
- The `_` (`::testing::_`) matches anything.
