### PR TITLE
Add default value support to INI file

### DIFF
--- a/srcStatic/FileSystemHelper.cpp
+++ b/srcStatic/FileSystemHelper.cpp
@@ -21,7 +21,7 @@ std::string GetOutpost2IniPath()
 
 std::string GetOutpost2IniSetting(const std::string& sectionName, const std::string& key)
 {
-	return IniFile::GetValue(GetOutpost2IniPath(), sectionName, key);
+	return IniFile::GetValue(GetOutpost2IniPath(), sectionName, key, "");
 }
 
 

--- a/srcStatic/IniFile.cpp
+++ b/srcStatic/IniFile.cpp
@@ -16,8 +16,8 @@ const std::string& IniFile::FileName() const {
 }
 
 // Get the value of a key within a section
-std::string IniFile::GetValue(const std::string& sectionName, const std::string& keyName) const {
-	return IniFile::GetValue(fileName, sectionName, keyName);
+std::string IniFile::GetValue(const std::string& sectionName, const std::string& keyName, const std::string& defaultValue) const {
+	return IniFile::GetValue(fileName, sectionName, keyName, defaultValue);
 }
 
 // Get the named section as a whole
@@ -55,8 +55,8 @@ void IniFile::SetValue(const std::string& sectionName, const std::string& keyNam
 // Allow fetching values without explicitly creating an object
 // This can be used for convenient one-off use
 // This may be less efficienct for repeated use to fetch multiple values
-std::string IniFile::GetValue(const std::string& fileName, const std::string& sectionName, const std::string& keyName) {
-	return IniFile::GetIniString(fileName.c_str(), sectionName.c_str(), keyName.c_str());
+std::string IniFile::GetValue(const std::string& fileName, const std::string& sectionName, const std::string& keyName, const std::string& defaultValue) {
+	return IniFile::GetIniString(fileName.c_str(), sectionName.c_str(), keyName.c_str(), defaultValue.c_str());
 }
 
 std::vector<std::string> IniFile::GetSectionNames(const std::string& fileName) {
@@ -86,7 +86,7 @@ void IniFile::SetValue(const std::string& fileName, const std::string& sectionNa
 
 // Delegate to Windows API to read INI file
 // Wrap result in std::string
-std::string IniFile::GetIniString(const char* fileName, const char* sectionName, const char* keyName) {
+std::string IniFile::GetIniString(const char* fileName, const char* sectionName, const char* keyName, const char* defaultValue) {
 	// Allocate buffer space
 	// The Win API GetPrivateProfileString has a maximum limit of 2^16 characters
 	// Trying to retrieve a longer string from the Win API will fail in unusual ways
@@ -94,7 +94,7 @@ std::string IniFile::GetIniString(const char* fileName, const char* sectionName,
 	resultString.resize(65536);
 
 	// Read result from INI file
-	DWORD returnSize = GetPrivateProfileStringA(sectionName, keyName, "", resultString.data(), resultString.size(), fileName);
+	DWORD returnSize = GetPrivateProfileStringA(sectionName, keyName, defaultValue, resultString.data(), resultString.size(), fileName);
 	// Resize to returned data size (which doesn't include null terminator)
 	resultString.resize(returnSize);
 
@@ -135,14 +135,14 @@ const std::string& IniSection::SectionName() const {
 }
 
 // Get the value of a key within a section
-std::string IniSection::GetValue(const std::string& keyName) const {
-	return IniFile::GetValue(fileName, sectionName, keyName);
+std::string IniSection::GetValue(const std::string& keyName, const std::string& defaultValue) const {
+	return IniFile::GetValue(fileName, sectionName, keyName, defaultValue);
 }
 
 // Get the value of a key within a section
 // Alternate syntax for GetValue
 std::string IniSection::operator[](std::string keyName) const {
-	return IniFile::GetValue(fileName, sectionName, keyName);
+	return IniFile::GetValue(fileName, sectionName, keyName, "");
 }
 
 // Get list of all Key names within a section

--- a/srcStatic/IniFile.h
+++ b/srcStatic/IniFile.h
@@ -14,7 +14,7 @@ public:
 	IniFile(std::string fileName);
 
 	const std::string& FileName() const;
-	std::string GetValue(const std::string& sectionName, const std::string& keyName) const;
+	std::string GetValue(const std::string& sectionName, const std::string& keyName, const std::string& defaultValue = "") const;
 	IniSection operator[](std::string sectionName) const;
 	std::vector<std::string> GetSectionNames() const;
 	std::vector<std::string> GetKeyNames(const std::string& sectionName);
@@ -23,7 +23,7 @@ public:
 	void ClearKey(const std::string& sectionName, const std::string& keyName);
 	void SetValue(const std::string& sectionName, const std::string& keyName, const std::string& value);
 
-	static std::string GetValue(const std::string& fileName, const std::string& sectionName, const std::string& keyName);
+	static std::string GetValue(const std::string& fileName, const std::string& sectionName, const std::string& keyName, const std::string& defaultValue);
 	static std::vector<std::string> GetSectionNames(const std::string& fileName);
 	static std::vector<std::string> GetKeyNames(const std::string& fileName, const std::string& sectionName);
 	static void ClearSection(const std::string& fileName, const std::string& sectionName);
@@ -33,7 +33,7 @@ public:
 private:
 	const std::string fileName;
 
-	static std::string GetIniString(const char* fileName, const char* sectionName, const char* keyName);
+	static std::string GetIniString(const char* fileName, const char* sectionName, const char* keyName, const char* defaultValue = "");
 	static std::vector<std::string> SplitResultOnNull(std::string arrayBuffer);
 };
 
@@ -45,7 +45,7 @@ public:
 
 	const std::string& FileName() const;
 	const std::string& SectionName() const;
-	std::string GetValue(const std::string& keyName) const;
+	std::string GetValue(const std::string& keyName, const std::string& defaultValue = "") const;
 	std::string operator[](std::string keyName) const;
 	std::vector<std::string> GetKeyNames();
 

--- a/test/IniFile.test.cpp
+++ b/test/IniFile.test.cpp
@@ -37,8 +37,8 @@ TEST(IniFile, StaticMethodsWriteRead) {
 	const std::string iniFileName{GetExeDirectory() + "TestIniFile.StaticMethods.ini"};
 
 	// Initially no data
-	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName1"));
-	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName2"));
+	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName1", ""));
+	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName2", ""));
 	// Initially no Section and Key names
 	EXPECT_EQ((std::vector<std::string>{}), IniFile::GetSectionNames(iniFileName));
 	EXPECT_EQ((std::vector<std::string>{}), IniFile::GetKeyNames(iniFileName, "SectionName"));
@@ -47,8 +47,8 @@ TEST(IniFile, StaticMethodsWriteRead) {
 	EXPECT_NO_THROW(IniFile::SetValue(iniFileName, "SectionName", "KeyName1", "SomeValue1"));
 	EXPECT_NO_THROW(IniFile::SetValue(iniFileName, "SectionName", "KeyName2", "SomeValue2"));
 	// Data now present
-	EXPECT_EQ("SomeValue1", IniFile::GetValue(iniFileName, "SectionName", "KeyName1"));
-	EXPECT_EQ("SomeValue2", IniFile::GetValue(iniFileName, "SectionName", "KeyName2"));
+	EXPECT_EQ("SomeValue1", IniFile::GetValue(iniFileName, "SectionName", "KeyName1", ""));
+	EXPECT_EQ("SomeValue2", IniFile::GetValue(iniFileName, "SectionName", "KeyName2", ""));
 	// Section and Key names now present
 	EXPECT_EQ((std::vector<std::string>{"SectionName"}), IniFile::GetSectionNames(iniFileName));
 	EXPECT_EQ((std::vector<std::string>{"KeyName1", "KeyName2"}), IniFile::GetKeyNames(iniFileName, "SectionName"));
@@ -56,8 +56,8 @@ TEST(IniFile, StaticMethodsWriteRead) {
 	// Delete a key
 	EXPECT_NO_THROW(IniFile::ClearKey(iniFileName, "SectionName", "KeyName1"));
 	// One value removed
-	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName1"));
-	EXPECT_EQ("SomeValue2", IniFile::GetValue(iniFileName, "SectionName", "KeyName2"));
+	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName1", ""));
+	EXPECT_EQ("SomeValue2", IniFile::GetValue(iniFileName, "SectionName", "KeyName2", ""));
 	// Section and one Key name now present
 	EXPECT_EQ((std::vector<std::string>{"SectionName"}), IniFile::GetSectionNames(iniFileName));
 	EXPECT_EQ((std::vector<std::string>{"KeyName2"}), IniFile::GetKeyNames(iniFileName, "SectionName"));
@@ -65,8 +65,8 @@ TEST(IniFile, StaticMethodsWriteRead) {
 	// Delete a section
 	EXPECT_NO_THROW(IniFile::ClearSection(iniFileName, "SectionName"));
 	// Both values removed
-	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName1"));
-	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName2"));
+	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName1", ""));
+	EXPECT_EQ("", IniFile::GetValue(iniFileName, "SectionName", "KeyName2", ""));
 	// No Section and Key names
 	EXPECT_EQ((std::vector<std::string>{}), IniFile::GetSectionNames(iniFileName));
 	EXPECT_EQ((std::vector<std::string>{}), IniFile::GetKeyNames(iniFileName, "SectionName"));


### PR DESCRIPTION
This closes #221.

It was not possible to add default value support for both the static method and the non-static method `GetValue`. Doing so would create ambiguity between them. Static methods may be called on member objects, and passing 3 parameters would make the call to which method ambiguous. It might be an explicitly specified value for the last parameter to the non-static method, or it might be a defaulted parameter call to the static method. The C++ standard does not allow such overloads.

For more information, see [C++ Overload Static Function with Non-Static Function](https://stackoverflow.com/questions/5365689/c-overload-static-function-with-non-static-function).
