### PR TITLE
Organize TApp event hook code

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -129,11 +129,6 @@ void OnInit()
 	volList->LoadVolFiles();
 }
 
-void OnShutdown()
-{
-	moduleLoader->UnloadModules();
-}
-
 void OnLoadShell()
 {
 	// Language support disabled. Was experimental before, but had version problems.
@@ -141,6 +136,11 @@ void OnLoadShell()
 
 	modulesRunning = true;
 	moduleLoader->RunModules();
+}
+
+void OnShutdown()
+{
+	moduleLoader->UnloadModules();
 }
 
 

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -143,6 +143,11 @@ void OnInit()
 	volList->LoadVolFiles();
 }
 
+void OnShutdown()
+{
+	moduleLoader->UnloadModules();
+}
+
 int TApp::Init()
 {
 	// Trigger event
@@ -157,7 +162,8 @@ void TApp::ShutDown()
 	// Call original function
 	(this->*GetMethodPointer<decltype(&TApp::ShutDown)>(0x004866E0))();
 
-	moduleLoader->UnloadModules();
+	// Trigger event
+	OnShutdown();
 }
 
 /**

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -148,6 +148,15 @@ void OnShutdown()
 	moduleLoader->UnloadModules();
 }
 
+void OnLoadShell()
+{
+	// Language support disabled. Was experimental before, but had version problems.
+	//LocalizeStrings();
+
+	modulesRunning = true;
+	moduleLoader->RunModules();
+}
+
 int TApp::Init()
 {
 	// Trigger event
@@ -208,13 +217,4 @@ HINSTANCE __stdcall LoadShell(LPCSTR lpLibFileName)
 	}
 
 	return hInstance;
-}
-
-void OnLoadShell()
-{
-	// Language support disabled. Was experimental before, but had version problems.
-	//LocalizeStrings();
-
-	modulesRunning = true;
-	moduleLoader->RunModules();
 }

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -163,7 +163,7 @@ public:
 };
 
 // Declaration for patch to LoadLibrary, where it loads OP2Shell.dll
-HINSTANCE __stdcall LoadShell(LPCSTR lpLibFileName);
+HINSTANCE LoadShell(LPCSTR lpLibFileName);
 
 DWORD* loadLibraryDataAddr = (DWORD*)0x00486E0A;
 DWORD loadLibraryNewAddr = (DWORD)LoadShell;

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -163,7 +163,9 @@ public:
 };
 
 // Declaration for patch to LoadLibrary, where it loads OP2Shell.dll
-HINSTANCE LoadShell(LPCSTR lpLibFileName);
+// Must use WINAPI macro (__stdcall specifier) to ensure callee cleans the stack
+// By default, for plain functions, the caller cleans the stack, rather than the callee
+HINSTANCE WINAPI LoadShell(LPCSTR lpLibFileName);
 
 DWORD* loadLibraryDataAddr = (DWORD*)0x00486E0A;
 DWORD loadLibraryNewAddr = (DWORD)LoadShell;

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -206,7 +206,7 @@ void TApp::ShutDown()
 	OnShutdown();
 }
 
-HINSTANCE LoadShell(LPCSTR lpLibFileName)
+HINSTANCE WINAPI LoadShell(LPCSTR lpLibFileName)
 {
 	// First try to load it
 	HINSTANCE hInstance = LoadLibraryA(lpLibFileName);

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -211,7 +211,7 @@ void TApp::ShutDown()
 	OnShutdown();
 }
 
-HINSTANCE __stdcall LoadShell(LPCSTR lpLibFileName)
+HINSTANCE LoadShell(LPCSTR lpLibFileName)
 {
 	// First try to load it
 	HINSTANCE hInstance = LoadLibraryA(lpLibFileName);

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -37,7 +37,9 @@ DWORD* loadLibraryDataAddr = (DWORD*)0x00486E0A;
 DWORD loadLibraryNewAddr = (DWORD)LoadShell;
 
 bool InstallTAppEventHooks();
+void OnInit();
 void OnLoadShell();
+void OnShutdown();
 
 // Warning: globals requiring dynamic initialization
 // Dynamic initialization order between translation units is unsequenced

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -16,7 +16,7 @@ void LocateVolFiles(const std::string& relativeDirectory = "");
 bool InstallDepPatch();
 
 
-// Brett208 12Dec17: Following code allows adding multiple language support to Outpost 2 menus.
+// Following code allows adding multiple language support to Outpost 2 menus.
 // Code is incomplete.
 // NLS for OP2
 //void LocalizeStrings();

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -119,7 +119,7 @@ bool InstallDepPatch()
 	return success;
 }
 
-int TApp::Init()
+void OnInit()
 {
 	// Install DEP patch so newer versions of Windows don't terminate the game
 	InstallDepPatch();
@@ -141,6 +141,12 @@ int TApp::Init()
 	LocateVolFiles(); //Searches root directory
 
 	volList->LoadVolFiles();
+}
+
+int TApp::Init()
+{
+	// Trigger event
+	OnInit();
 
 	// Call original function
 	return (this->*GetMethodPointer<decltype(&TApp::Init)>(0x00485B20))();

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -15,26 +15,12 @@
 void LocateVolFiles(const std::string& relativeDirectory = "");
 bool InstallDepPatch();
 
-// Declaration for patch to LoadLibrary, where it loads OP2Shell.dll
-HINSTANCE __stdcall LoadShell(LPCSTR lpLibFileName);
 
 // Brett208 12Dec17: Following code allows adding multiple language support to Outpost 2 menus.
 // Code is incomplete.
 // NLS for OP2
 //void LocalizeStrings();
 void ConvLangStr(char *instr, char *outstr);
-
-// TApp is an exported class from Outpost2.exe.
-// We need to replace some of its methods with a compatible signature
-class TApp
-{
-public:
-	int Init();
-	void ShutDown();
-};
-
-DWORD* loadLibraryDataAddr = (DWORD*)0x00486E0A;
-DWORD loadLibraryNewAddr = (DWORD)LoadShell;
 
 bool InstallTAppEventHooks();
 void OnInit();
@@ -176,6 +162,22 @@ void LocateVolFiles(const std::string& relativeDirectory)
 		Log(e.what());
 	}
 }
+
+
+// TApp is an exported class from Outpost2.exe.
+// We need to replace some of its methods with a compatible signature
+class TApp
+{
+public:
+	int Init();
+	void ShutDown();
+};
+
+// Declaration for patch to LoadLibrary, where it loads OP2Shell.dll
+HINSTANCE __stdcall LoadShell(LPCSTR lpLibFileName);
+
+DWORD* loadLibraryDataAddr = (DWORD*)0x00486E0A;
+DWORD loadLibraryNewAddr = (DWORD)LoadShell;
 
 
 bool InstallTAppEventHooks()

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -14,14 +14,6 @@
 
 void LocateVolFiles(const std::string& relativeDirectory = "");
 bool InstallDepPatch();
-
-
-// Following code allows adding multiple language support to Outpost 2 menus.
-// Code is incomplete.
-// NLS for OP2
-//void LocalizeStrings();
-void ConvLangStr(char *instr, char *outstr);
-
 bool InstallTAppEventHooks();
 void OnInit();
 void OnLoadShell();
@@ -119,9 +111,6 @@ void OnInit()
 
 void OnLoadShell()
 {
-	// Language support disabled. Was experimental before, but had version problems.
-	//LocalizeStrings();
-
 	modulesRunning = true;
 	moduleLoader->RunModules();
 }


### PR DESCRIPTION
This is cleanup to support Issue #194. The `TApp` related code still hasn't been moved to it's own file, but has been nicely organized together at the bottom of DllMain.cpp. Some decisions will need to be made concerning events, and event handler visibility before the code can be moved out. For now this seems like a good stopping point.
