### PR TITLE
Load VOL files from INI module folders

### DIFF
--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -1,5 +1,6 @@
 #include "IniModule.h"
 #include "../Log.h"
+#include "../FsInclude.h"
 #include <utility>
 #include <stdexcept>
 
@@ -39,4 +40,10 @@ bool IniModule::Unload()
 	FreeLibrary(moduleDllHandle);
 
 	return success;
+}
+
+std::string IniModule::Directory()
+{
+	auto dllSetting = iniSection["Dll"];
+	return fs::path(dllSetting).remove_filename().string();
 }

--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -50,5 +50,6 @@ std::string IniModule::Directory()
 
 std::string IniModule::DllName()
 {
-	return iniSection["Dll"];
+	auto defaultDllName = (fs::path(Name()) / "op2mod.dll").string();
+	return iniSection.GetValue("Dll", defaultDllName);
 }

--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -10,7 +10,7 @@ IniModule::IniModule(IniSection iniSection)
 {
 	try {
 		// Get the DLL name from the corresponding section
-		LoadModuleDll(iniSection["Dll"]);
+		LoadModuleDll(DllName());
 	}
 	catch (const std::exception& error) {
 		throw std::runtime_error("Unable to load dll for module " + Name() + ". " + std::string(error.what()));
@@ -44,6 +44,11 @@ bool IniModule::Unload()
 
 std::string IniModule::Directory()
 {
-	auto dllSetting = iniSection["Dll"];
+	auto dllSetting = DllName();
 	return fs::path(dllSetting).remove_filename().string();
+}
+
+std::string IniModule::DllName()
+{
+	return iniSection["Dll"];
 }

--- a/srcStatic/GameModules/IniModule.h
+++ b/srcStatic/GameModules/IniModule.h
@@ -15,6 +15,8 @@ public:
 	std::string Directory() override;
 
 private:
+	std::string DllName();
+
 	// Export (not absolutely required, but should be used if any additional parameters are read from the .ini file)
 	typedef void(*LoadModuleFunction)(const char* iniSectionName);
 	typedef bool(*UnloadModuleFunction)();

--- a/srcStatic/GameModules/IniModule.h
+++ b/srcStatic/GameModules/IniModule.h
@@ -12,6 +12,8 @@ public:
 	void Load() override;
 	bool Unload() override;
 
+	std::string Directory() override;
+
 private:
 	// Export (not absolutely required, but should be used if any additional parameters are read from the .ini file)
 	typedef void(*LoadModuleFunction)(const char* iniSectionName);


### PR DESCRIPTION
This closes #147.

----

I would like to add a test for the new `IniModule::Directory()` method. In particular, I want to verify there is a trailing slash (which I manually verified). However, the `IniModule` class tries to load a DLL from the constructor, and throws an exception if it fails. As we are not including an INI module for use in unit testing, this puts testing of `IniModule` methods outside the current scope of unit testing. Only module load failure conditions are currently unit testable. For method functions, we would either need to add testing elsewhere, or rework the class so it can be instantiated without a corresponding DLL.
