### PR TITLE
Unify Detection of Functions Exported by Modules

### DIFF
--- a/srcStatic/GameModules/ConsoleModule.cpp
+++ b/srcStatic/GameModules/ConsoleModule.cpp
@@ -1,10 +1,9 @@
 #include "ConsoleModule.h"
 #include "../FileSystemHelper.h"
 #include "../FsInclude.h"
-#include "../Log.h"
 #include "../WindowsErrorCode.h"
-#include <windows.h>
 #include <stdexcept>
+
 
 ConsoleModule::ConsoleModule(const std::string& moduleName) : DllModule(moduleName), 
 	moduleDirectory((fs::path(GetExeDirectory()) / moduleName).string() + "\\")
@@ -20,38 +19,4 @@ ConsoleModule::ConsoleModule(const std::string& moduleName) : DllModule(moduleNa
 	}
 
 	LoadModuleDll(dllPath);
-
-	// Search for dll's initialization & destroy functions
-	loadModuleFunction = (LoadModuleFunction)GetProcAddress(moduleDllHandle, "mod_init");
-	unloadModuleFunction = (UnloadModuleFunction)GetProcAddress(moduleDllHandle, "mod_destroy");
-	runModuleFunction = (RunModuleFunction)GetProcAddress(moduleDllHandle, "mod_run");
-}
-
-void ConsoleModule::Load()
-{
-	if (loadModuleFunction != nullptr) {
-		loadModuleFunction();
-	}
-}
-
-bool ConsoleModule::Unload()
-{
-	bool success = true;
-
-	if (unloadModuleFunction != nullptr) {
-		success = unloadModuleFunction();
-	}
-
-	if (moduleDllHandle != nullptr) {
-		FreeLibrary(moduleDllHandle);
-	}
-
-	return success;
-}
-
-void ConsoleModule::Run()
-{
-	if (runModuleFunction != nullptr) {
-		runModuleFunction();
-	}
 }

--- a/srcStatic/GameModules/ConsoleModule.h
+++ b/srcStatic/GameModules/ConsoleModule.h
@@ -9,20 +9,8 @@ class ConsoleModule : public DllModule
 public:
 	ConsoleModule(const std::string& moduleRelativeDirectory);
 
-	void Load() override;
-	bool Unload() override;
-	void Run() override;
-
 	inline std::string Directory() override { return moduleDirectory; }
 
 private:
-	typedef void(*LoadModuleFunction)();
-	typedef bool(*UnloadModuleFunction)();
-	typedef void(*RunModuleFunction)();
-
 	const std::string moduleDirectory;
-
-	LoadModuleFunction loadModuleFunction = nullptr;
-	UnloadModuleFunction unloadModuleFunction = nullptr;
-	RunModuleFunction runModuleFunction = nullptr;
 };

--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -1,4 +1,5 @@
 #include "DllModule.h"
+#include "../Log.h"
 #include "../WindowsErrorCode.h"
 #include <stdexcept>
 
@@ -60,6 +61,9 @@ bool DllModule::Unload()
 	}
 	else if (unloadModuleFunctionConsole != nullptr) {
 		success = unloadModuleFunctionConsole();
+		if (!success) {
+			Log("Module reports error during unload: " + Name());
+		}
 	}
 
 	if (moduleDllHandle != nullptr) {

--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -30,9 +30,9 @@ void DllModule::DetectExportedModuleFunctions()
 		loadModuleFunctionConsole = (LoadModuleFunctionConsole)GetProcAddress(moduleDllHandle, "mod_init");
 	}
 
-	unloadModuleFunction = (UnloadModuleFunction)GetProcAddress(moduleDllHandle, "DestroyMod");
-	if (unloadModuleFunction == nullptr) {
-		unloadModuleFunction = (UnloadModuleFunction)GetProcAddress(moduleDllHandle, "mod_destroy");
+	unloadModuleFunctionIni = (UnloadModuleFunctionIni)GetProcAddress(moduleDllHandle, "DestroyMod");
+	if (unloadModuleFunctionIni == nullptr) {
+		unloadModuleFunctionConsole = (UnloadModuleFunctionConsole)GetProcAddress(moduleDllHandle, "mod_destroy");
 	}
 
 	runModuleFunction = (RunModuleFunction)GetProcAddress(moduleDllHandle, "RunMod");
@@ -55,8 +55,11 @@ bool DllModule::Unload()
 {
 	bool success = true;
 
-	if (unloadModuleFunction != nullptr) {
-		success = unloadModuleFunction();
+	if (unloadModuleFunctionIni != nullptr) {
+		success = unloadModuleFunctionIni();
+	}
+	else if (unloadModuleFunctionConsole != nullptr) {
+		unloadModuleFunctionConsole();
 	}
 
 	if (moduleDllHandle != nullptr) {

--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -56,10 +56,10 @@ bool DllModule::Unload()
 	bool success = true;
 
 	if (unloadModuleFunctionIni != nullptr) {
-		success = unloadModuleFunctionIni();
+		unloadModuleFunctionIni();
 	}
 	else if (unloadModuleFunctionConsole != nullptr) {
-		unloadModuleFunctionConsole();
+		success = unloadModuleFunctionConsole();
 	}
 
 	if (moduleDllHandle != nullptr) {

--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -25,19 +25,19 @@ void DllModule::LoadModuleDll(const std::string& dllPath)
 
 void DllModule::DetectExportedModuleFunctions()
 {
-	loadModuleFunctionIni = (LoadModuleFunctionIni)GetProcAddress(moduleDllHandle, "InitMod");
+	loadModuleFunctionIni = reinterpret_cast<LoadModuleFunctionIni>(GetProcAddress(moduleDllHandle, "InitMod"));
 	if (loadModuleFunctionIni == nullptr) {
-		loadModuleFunctionConsole = (LoadModuleFunctionConsole)GetProcAddress(moduleDllHandle, "mod_init");
+		loadModuleFunctionConsole = reinterpret_cast<LoadModuleFunctionConsole>(GetProcAddress(moduleDllHandle, "mod_init"));
 	}
 
-	unloadModuleFunctionIni = (UnloadModuleFunctionIni)GetProcAddress(moduleDllHandle, "DestroyMod");
+	unloadModuleFunctionIni = reinterpret_cast<UnloadModuleFunctionIni>(GetProcAddress(moduleDllHandle, "DestroyMod"));
 	if (unloadModuleFunctionIni == nullptr) {
-		unloadModuleFunctionConsole = (UnloadModuleFunctionConsole)GetProcAddress(moduleDllHandle, "mod_destroy");
+		unloadModuleFunctionConsole = reinterpret_cast<UnloadModuleFunctionConsole>(GetProcAddress(moduleDllHandle, "mod_destroy"));
 	}
 
-	runModuleFunction = (RunModuleFunction)GetProcAddress(moduleDllHandle, "RunMod");
+	runModuleFunction = reinterpret_cast<RunModuleFunction>(GetProcAddress(moduleDllHandle, "RunMod"));
 	if (runModuleFunction == nullptr) {
-		runModuleFunction = (RunModuleFunction)GetProcAddress(moduleDllHandle, "mod_run");
+		runModuleFunction = reinterpret_cast<RunModuleFunction>(GetProcAddress(moduleDllHandle, "mod_run"));
 	}
 }
 

--- a/srcStatic/GameModules/DllModule.h
+++ b/srcStatic/GameModules/DllModule.h
@@ -11,9 +11,29 @@ class DllModule : public GameModule
 public:
 	DllModule(const std::string& moduleName);
 
+	void Load() override;
+	bool Unload() override;
+	void Run() override;
+
 protected:
 	HINSTANCE moduleDllHandle = nullptr;
 
 	// Call from constructor of derived class
 	void LoadModuleDll(const std::string& dllPath);
+
+private:
+	// ALl exported dll functions have the same signature except for Load (Init). 
+	// The exported naming schema is different between console and ini functions
+	typedef void(*LoadModuleFunctionIni)(const char* iniSectionName);
+	typedef void(*LoadModuleFunctionConsole)();
+	typedef bool(*UnloadModuleFunction)();
+	typedef void(*RunModuleFunction)();
+
+	// Search for dll's initialization, run & destroy functions
+	void DetectExportedModuleFunctions();
+
+	LoadModuleFunctionIni loadModuleFunctionIni = nullptr;
+	LoadModuleFunctionConsole loadModuleFunctionConsole = nullptr;
+	UnloadModuleFunction unloadModuleFunction = nullptr;
+	RunModuleFunction runModuleFunction = nullptr;
 };

--- a/srcStatic/GameModules/DllModule.h
+++ b/srcStatic/GameModules/DllModule.h
@@ -24,11 +24,11 @@ protected:
 private:
 	// ALl exported dll functions have the same signature except for Load (Init). 
 	// The exported naming schema is different between console and ini functions
-	typedef void(*LoadModuleFunctionIni)(const char* iniSectionName);
-	typedef void(*LoadModuleFunctionConsole)();
-	typedef void(*UnloadModuleFunctionIni)();
-	typedef bool(*UnloadModuleFunctionConsole)();
-	typedef void(*RunModuleFunction)();
+	using LoadModuleFunctionIni = void(*)(const char* iniSectionName);
+	using LoadModuleFunctionConsole = void(*)();
+	using UnloadModuleFunctionIni = void(*)();
+	using UnloadModuleFunctionConsole = bool(*)();
+	using RunModuleFunction = void(*)();
 
 	// Search for dll's initialization, run & destroy functions
 	void DetectExportedModuleFunctions();

--- a/srcStatic/GameModules/DllModule.h
+++ b/srcStatic/GameModules/DllModule.h
@@ -22,7 +22,6 @@ protected:
 	void LoadModuleDll(const std::string& dllPath);
 
 private:
-	// ALl exported dll functions have the same signature except for Load (Init). 
 	// The exported naming schema is different between console and ini functions
 	using LoadModuleFunctionIni = void(*)(const char* iniSectionName);
 	using LoadModuleFunctionConsole = void(*)();

--- a/srcStatic/GameModules/DllModule.h
+++ b/srcStatic/GameModules/DllModule.h
@@ -26,8 +26,8 @@ private:
 	// The exported naming schema is different between console and ini functions
 	typedef void(*LoadModuleFunctionIni)(const char* iniSectionName);
 	typedef void(*LoadModuleFunctionConsole)();
-	typedef bool(*UnloadModuleFunctionIni)();
-	typedef void(*UnloadModuleFunctionConsole)();
+	typedef void(*UnloadModuleFunctionIni)();
+	typedef bool(*UnloadModuleFunctionConsole)();
 	typedef void(*RunModuleFunction)();
 
 	// Search for dll's initialization, run & destroy functions

--- a/srcStatic/GameModules/DllModule.h
+++ b/srcStatic/GameModules/DllModule.h
@@ -26,7 +26,8 @@ private:
 	// The exported naming schema is different between console and ini functions
 	typedef void(*LoadModuleFunctionIni)(const char* iniSectionName);
 	typedef void(*LoadModuleFunctionConsole)();
-	typedef bool(*UnloadModuleFunction)();
+	typedef bool(*UnloadModuleFunctionIni)();
+	typedef void(*UnloadModuleFunctionConsole)();
 	typedef void(*RunModuleFunction)();
 
 	// Search for dll's initialization, run & destroy functions
@@ -34,6 +35,7 @@ private:
 
 	LoadModuleFunctionIni loadModuleFunctionIni = nullptr;
 	LoadModuleFunctionConsole loadModuleFunctionConsole = nullptr;
-	UnloadModuleFunction unloadModuleFunction = nullptr;
+	UnloadModuleFunctionIni unloadModuleFunctionIni = nullptr;
+	UnloadModuleFunctionConsole unloadModuleFunctionConsole = nullptr;
 	RunModuleFunction runModuleFunction = nullptr;
 };

--- a/srcStatic/GameModules/IniModule.cpp
+++ b/srcStatic/GameModules/IniModule.cpp
@@ -1,6 +1,4 @@
 #include "IniModule.h"
-#include "../Log.h"
-#include <utility>
 #include <stdexcept>
 
 
@@ -14,29 +12,4 @@ IniModule::IniModule(IniSection iniSection)
 	catch (const std::exception& error) {
 		throw std::runtime_error("Unable to load dll for module " + Name() + ". " + std::string(error.what()));
 	}
-
-	// Search for dll's initialization & destroy functions
-	loadModuleFunction = (LoadModuleFunction)GetProcAddress(moduleDllHandle, "InitMod");
-	unloadModuleFunction = (UnloadModuleFunction)GetProcAddress(moduleDllHandle, "DestroyMod");
 };
-
-void IniModule::Load()
-{
-	// Call the InitMod function if it exists
-	if (loadModuleFunction != nullptr) {
-		loadModuleFunction(Name().c_str());
-	}
-}
-
-bool IniModule::Unload()
-{
-	bool success = true;
-
-	if (unloadModuleFunction != nullptr) {
-		success = unloadModuleFunction();
-	}
-
-	FreeLibrary(moduleDllHandle);
-
-	return success;
-}

--- a/srcStatic/GameModules/IniModule.h
+++ b/srcStatic/GameModules/IniModule.h
@@ -9,16 +9,6 @@ class IniModule : public DllModule
 public:
 	IniModule(IniSection iniSection);
 
-	void Load() override;
-	bool Unload() override;
-
 private:
-	// Export (not absolutely required, but should be used if any additional parameters are read from the .ini file)
-	typedef void(*LoadModuleFunction)(const char* iniSectionName);
-	typedef bool(*UnloadModuleFunction)();
-
 	IniSection iniSection;
-
-	LoadModuleFunction loadModuleFunction;
-	UnloadModuleFunction unloadModuleFunction;
 };


### PR DESCRIPTION
I think this breaks NetFix from loading but I haven't figured out why yet.