### PR TITLE
Define makefile rule to build all unit test projects

### DIFF
--- a/makefile-generic.mk
+++ b/makefile-generic.mk
@@ -308,6 +308,11 @@ $(1)_LDLIBS ?= $$($(3)_LDLIBS) $$($(1)_inputLibFileIncludeOptions) $(gtest_LINK_
 # Define the Unit Test project
 $(call DefineCppProject,$(1),$(BUILDDIR)/$(config)/$(1)/unitTest.exe,$(2),$(3))
 
+# Define unit test building rules
+.PHONY: test
+# Master rule to build all unit tests
+test: $(1)
+
 # Define unit test running rules
 .PHONY: check check-$(1)
 # Rule to run this specific unit test


### PR DESCRIPTION
Linux only change.

The new `test` target builds all unit test projects. It does not try to run them. This corresponds with the old `check` target, which runs all unit test projects (and optionally builds them if they are out of date).

Having two separate rules makes it easier to build the unit test code in parallel, yet still run the unit test code sequentially. This helps avoid interleaved output in the terminal from two unit tests running in parallel.
