### PR TITLE
Use `vector` for `AddVolToList`

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -44,7 +44,6 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 
 		// Construct global objects
 		vols = std::make_unique<std::vector<std::string>>();
-		volList = std::make_unique<VolList>();
 		moduleLoader = std::make_unique<ModuleLoader>();
 
 		// Set load offset for Outpost2.exe module, used during memory patching
@@ -102,6 +101,10 @@ void OnInit()
 
 	// Load all active modules from the .ini file
 	moduleLoader->LoadModules();
+
+	// Load VOL files
+
+	volList = std::make_unique<VolList>();
 
 	for (const auto& volFilename : *vols) {
 		volList->AddVolFile(volFilename);

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -1,5 +1,6 @@
 #include "Globals.h"
 #include "ModuleLoader.h"
+#include "VolList.h"
 #include "StringConversion.h"
 #include "OP2Memory.h"
 #include "FileSystemHelper.h"
@@ -29,6 +30,7 @@ LoggerFile loggerFile; // Logging to file in Outpost 2 folder
 LoggerMessageBox loggerMessageBox; // Logging to pop-up message box
 LoggerDistributor loggerDistributor({&loggerFile, &loggerMessageBox});
 LoggerDebug loggerDebug;
+std::unique_ptr<VolList> volList;
 
 
 BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
@@ -41,6 +43,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 		SetLoggerDebug(&loggerDebug);
 
 		// Construct global objects
+		vols = std::make_unique<std::vector<std::string>>();
 		volList = std::make_unique<VolList>();
 		moduleLoader = std::make_unique<ModuleLoader>();
 
@@ -99,6 +102,10 @@ void OnInit()
 
 	// Load all active modules from the .ini file
 	moduleLoader->LoadModules();
+
+	for (const auto& volFilename : *vols) {
+		volList->AddVolFile(volFilename);
+	}
 
 	// Find VOL files from additional folders
 	for (std::size_t i = 0; i < moduleLoader->Count(); ++i) {

--- a/srcDLL/Globals.cpp
+++ b/srcDLL/Globals.cpp
@@ -5,5 +5,5 @@
 // When set, attempting further initialization commands will cause errors.
 bool appInitialized = false;
 
-std::unique_ptr<VolList> volList;
+std::unique_ptr<std::vector<std::string>> vols;
 std::unique_ptr<ModuleLoader> moduleLoader;

--- a/srcDLL/Globals.h
+++ b/srcDLL/Globals.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "VolList.h"
 #include "ModuleLoader.h"
 #include <memory>
+#include <vector>
+#include <string>
 
 
 extern bool appInitialized;
-extern std::unique_ptr<VolList> volList;
+extern std::unique_ptr<std::vector<std::string>> vols;
 extern std::unique_ptr<ModuleLoader> moduleLoader;

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -77,7 +77,7 @@ OP2EXT_API void AddVolToList(const char* volFilename)
 		PostError("VOLs may not be added to the list after game startup.");
 	}
 	else {
-		volList->AddVolFile(volFilename);
+		vols->push_back(volFilename);
 	}
 }
 


### PR DESCRIPTION
This is a bit of background work for issue #239. This collects all uses of `VolList` into the `OnInit()` method in DllMain.cpp.

The longer term plan is to rework `OnInit()` to build the full VOL list first, and then pass the full list to a new `VolList` constructor. Currently the code is still constructing an empty `VolList` and then adding VOL files one at a time.

I'm stopping here to come up with a plan for the next part. The VOL list building could be done in one of many ways, and all of them are a bit awkward with current C++ features.
