### PR TITLE
Update `VolList` to have `const` members

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -112,9 +112,10 @@ void OnInit()
 	*vols += FindVolFilesInDirectory("Addon");
 	*vols += FindVolFilesInDirectory("");
 
-	// Load VOL files
+	// Set Outpost2.exe's VOL list
+	// The game will load the files in this list shortly
 	volList = std::make_unique<VolList>(*vols);
-	volList->LoadVolFiles();
+	volList->Activate();
 
 	appInitialized = true;
 }

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -102,26 +102,23 @@ void OnInit()
 	// Load all active modules from the .ini file
 	moduleLoader->LoadModules();
 
-	// Load VOL files
-
-	volList = std::make_unique<VolList>();
-
-	for (const auto& volFilename : *vols) {
-		volList->AddVolFile(volFilename);
-	}
-
 	// Find VOL files from additional folders
 	for (std::size_t i = 0; i < moduleLoader->Count(); ++i) {
 		const auto& moduleDirectory = moduleLoader->GetModuleDirectory(i);
 		if (!moduleDirectory.empty()) {
-			volList->AddVolFilesFromDirectory(moduleDirectory);
+			*vols += FindVolFilesInDirectory(moduleDirectory);
 		}
 	}
+	*vols += FindVolFilesInDirectory("Addon");
+	*vols += FindVolFilesInDirectory("");
 
-	volList->AddVolFilesFromDirectory("Addon");
-	volList->AddVolFilesFromDirectory("");
-
+	// Load VOL files
+	volList = std::make_unique<VolList>();
+	for (const auto& volFilename : *vols) {
+		volList->AddVolFile(volFilename);
+	}
 	volList->LoadVolFiles();
+
 	appInitialized = true;
 }
 

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -113,10 +113,7 @@ void OnInit()
 	*vols += FindVolFilesInDirectory("");
 
 	// Load VOL files
-	volList = std::make_unique<VolList>();
-	for (const auto& volFilename : *vols) {
-		volList->AddVolFile(volFilename);
-	}
+	volList = std::make_unique<VolList>(*vols);
 	volList->LoadVolFiles();
 
 	appInitialized = true;

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -68,7 +68,7 @@ bool Op2MemSet(void* destBaseAddr, unsigned char value, int size)
 	);
 }
 
-bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size)
+bool Op2MemCopy(void* destBaseAddr, const void* sourceAddr, int size)
 {
 	return Op2MemEdit(
 		destBaseAddr,
@@ -82,7 +82,7 @@ bool Op2MemSetDword(void* destBaseAddr, int dword)
 	return Op2MemCopy(destBaseAddr, &dword, sizeof(dword));
 }
 
-bool Op2MemSetDword(void* destBaseAddr, void* dword)
+bool Op2MemSetDword(void* destBaseAddr, const void* dword)
 {
 	return Op2MemCopy(destBaseAddr, &dword, sizeof(dword));
 }
@@ -93,7 +93,7 @@ bool Op2MemSetDword(void* destBaseAddr, void* dword)
 //   CALL someMethod  ; Encoded as E8 00040000
 //   postCallInstruction:
 // The `callOffset` parameter is the address of the encoded DWORD
-bool Op2RelinkCall(std::size_t callOffset, void* newFunctionAddress)
+bool Op2RelinkCall(std::size_t callOffset, const void* newFunctionAddress)
 {
 	if (!memoryPatchingEnabled) {
 		return false;

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -8,11 +8,11 @@
 
 bool EnableOp2MemoryPatching();
 
-bool Op2MemCopy(void* destBaseAddr, void* sourceAddr, int size);
+bool Op2MemCopy(void* destBaseAddr, const void* sourceAddr, int size);
 bool Op2MemSet(void* destBaseAddr, unsigned char value, int size);
 bool Op2MemSetDword(void* destBaseAddr, int dword);
-bool Op2MemSetDword(void* destBaseAddr, void* dword);
-bool Op2RelinkCall(std::size_t callOffset, void* newFunctionAddress);
+bool Op2MemSetDword(void* destBaseAddr, const void* dword);
+bool Op2RelinkCall(std::size_t callOffset, const void* newFunctionAddress);
 bool Op2UnprotectMemory(std::size_t destBaseAddr, std::size_t size);
 
 

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -36,20 +36,6 @@ void VolList::AddVolFile(std::string volPath)
 	volPaths.push_back(std::move(volPath));
 }
 
-void VolList::AddVolFilesFromDirectory(const std::string& relativeDirectory)
-{
-	try {
-		const auto volPaths = FindFilesWithExtension(GetExeDirectory(), relativeDirectory, ".vol");
-
-		for (const auto& volPath : volPaths) {
-			AddVolFile(volPath);
-		}
-	}
-	catch (const std::exception& e) {
-		LogMessage("Error attempting to locate vol files in provided directory " + relativeDirectory + ". " + std::string(e.what()));
-	}
-}
-
 // Patch reference to the original VolSearchEntry[] in Outpost2.exe to point to a replacement
 // Note: Addresses of the original array (at various offsets) are hardcoded into several instructions
 void VolList::LoadVolFiles()

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -6,6 +6,18 @@
 #include <utility>
 
 
+std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDirectory)
+{
+	try {
+		return FindFilesWithExtension(GetExeDirectory(), relativeDirectory, ".vol");
+	}
+	catch (const std::exception& e) {
+		LogMessage("Error finding VOL files in directory: " + relativeDirectory + " : " + std::string(e.what()));
+		return {};
+	}
+}
+
+
 void VolList::AddVolFile(std::string volPath)
 {
 	LogDebug("Add file to VolList: " + volPath + "\n");

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -38,12 +38,6 @@ VolList::VolList(std::vector<std::string> volPaths) :
 	}
 }
 
-void VolList::AddVolFile(std::string volPath)
-{
-	LogDebug("Add file to VolList: " + volPath + "\n");
-	volPaths.push_back(std::move(volPath));
-}
-
 // Patch reference to the original VolSearchEntry[] in Outpost2.exe to point to a replacement
 // Note: Addresses of the original array (at various offsets) are hardcoded into several instructions
 void VolList::LoadVolFiles()

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -30,8 +30,14 @@ std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDire
 }
 
 
+VolList::VolList() :
+	volSearchEntryList(CreateVolSearchEntryList(this->volPaths))
+{
+}
+
 VolList::VolList(std::vector<std::string> volPaths) :
-	volPaths(std::move(volPaths))
+	volPaths(std::move(volPaths)),
+	volSearchEntryList(CreateVolSearchEntryList(this->volPaths))
 {
 	for (const auto& volPath : volPaths) {
 		LogDebug("Add file to VolList: " + volPath + "\n");
@@ -42,8 +48,6 @@ VolList::VolList(std::vector<std::string> volPaths) :
 // Note: Addresses of the original array (at various offsets) are hardcoded into several instructions
 void VolList::LoadVolFiles()
 {
-	volSearchEntryList = CreateVolSearchEntryList(volPaths);
-
 	// Addresses at the start of the array are used for loop initial conditions
 	auto* arrayStart1 = &volSearchEntryList[0].pFilename;
 	auto* arrayStart2 = &volSearchEntryList[0].volFileRStream;

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -6,6 +6,12 @@
 #include <utility>
 
 
+std::vector<std::string> operator+(std::vector<std::string> lhs, const std::vector<std::string>& rhs)
+{
+	lhs.insert(lhs.end(), rhs.begin(), rhs.end());
+	return lhs;
+}
+
 std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDirectory)
 {
 	try {

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -42,7 +42,7 @@ VolList::VolList(std::vector<std::string> volPaths) :
 // Note: Addresses of the original array (at various offsets) are hardcoded into several instructions
 void VolList::LoadVolFiles()
 {
-	CreateVolSearchEntryList();
+	volSearchEntryList = CreateVolSearchEntryList(volPaths);
 
 	// Addresses at the start of the array are used for loop initial conditions
 	auto* arrayStart1 = &volSearchEntryList[0].pFilename;
@@ -83,9 +83,9 @@ void VolList::LoadVolFiles()
 // Changes to strings (such as by a vector re-allocation which moves strings), will invalidate cached c_str() pointers.
 // In particular, MSVC and other compilers implement the Small String Optimization (SSO).
 // SSO will exhibit problems for small strings when improperly cached c_str() pointers are invalidated by a move.
-void VolList::CreateVolSearchEntryList()
+std::vector<VolList::VolSearchEntry> VolList::CreateVolSearchEntryList(const std::vector<std::string>& volPaths)
 {
-	volSearchEntryList.clear();
+	std::vector<VolSearchEntry> volSearchEntryList;
 
 	for (const auto& volPath : volPaths) {
 		volSearchEntryList.push_back(VolSearchEntry::Init(volPath.c_str()));
@@ -93,4 +93,6 @@ void VolList::CreateVolSearchEntryList()
 
 	// Add end of volFileEntries search item (terminator entry)
 	volSearchEntryList.push_back(VolSearchEntry::Init(nullptr));
+
+	return volSearchEntryList;
 }

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -46,7 +46,7 @@ VolList::VolList(std::vector<std::string> volPaths) :
 
 // Patch reference to the original VolSearchEntry[] in Outpost2.exe to point to a replacement
 // Note: Addresses of the original array (at various offsets) are hardcoded into several instructions
-void VolList::LoadVolFiles()
+void VolList::Activate()
 {
 	// Addresses at the start of the array are used for loop initial conditions
 	auto* arrayStart1 = &volSearchEntryList[0].pFilename;

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -30,6 +30,14 @@ std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDire
 }
 
 
+VolList::VolList(std::vector<std::string> volPaths) :
+	volPaths(std::move(volPaths))
+{
+	for (const auto& volPath : volPaths) {
+		LogDebug("Add file to VolList: " + volPath + "\n");
+	}
+}
+
 void VolList::AddVolFile(std::string volPath)
 {
 	LogDebug("Add file to VolList: " + volPath + "\n");

--- a/srcStatic/VolList.cpp
+++ b/srcStatic/VolList.cpp
@@ -6,9 +6,15 @@
 #include <utility>
 
 
-std::vector<std::string> operator+(std::vector<std::string> lhs, const std::vector<std::string>& rhs)
+std::vector<std::string>& operator+=(std::vector<std::string>& lhs, const std::vector<std::string>& rhs)
 {
 	lhs.insert(lhs.end(), rhs.begin(), rhs.end());
+	return lhs;
+}
+
+std::vector<std::string> operator+(std::vector<std::string> lhs, const std::vector<std::string>& rhs)
+{
+	lhs += rhs;
 	return lhs;
 }
 

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -13,6 +13,8 @@ std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDire
 class VolList
 {
 public:
+	VolList() = default;
+	VolList(std::vector<std::string> volPaths);
 	void AddVolFile(std::string volPath);
 
 	// Load all identified vol files into Outpost 2's memory.

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -15,9 +15,6 @@ class VolList
 public:
 	void AddVolFile(std::string volPath);
 
-	// Does not recursively search subdirectories.
-	void AddVolFilesFromDirectory(const std::string& relativeDirectory);
-
 	// Load all identified vol files into Outpost 2's memory.
 	void LoadVolFiles();
 

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -36,6 +36,5 @@ private:
 	const std::vector<std::string> volPaths;
 	std::vector<VolSearchEntry> volSearchEntryList;
 
-	// Return size of VolSearchEntryList
-	void CreateVolSearchEntryList();
+	static std::vector<VolSearchEntry> CreateVolSearchEntryList(const std::vector<std::string>& volPaths);
 };

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -4,6 +4,9 @@
 #include <vector>
 
 
+std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDirectory);
+
+
 class VolList
 {
 public:

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -33,7 +33,7 @@ private:
 		}
 	};
 
-	std::vector<std::string> volPaths;
+	const std::vector<std::string> volPaths;
 	std::vector<VolSearchEntry> volSearchEntryList;
 
 	// Return size of VolSearchEntryList

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -15,7 +15,6 @@ class VolList
 public:
 	VolList() = default;
 	VolList(std::vector<std::string> volPaths);
-	void AddVolFile(std::string volPath);
 
 	// Load all identified vol files into Outpost 2's memory.
 	void LoadVolFiles();

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 
+std::vector<std::string>& operator+=(std::vector<std::string>& lhs, const std::vector<std::string>& rhs);
 std::vector<std::string> operator+(std::vector<std::string> lhs, const std::vector<std::string>& rhs);
 
 std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDirectory);

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -16,8 +16,7 @@ public:
 	VolList();
 	VolList(std::vector<std::string> volPaths);
 
-	// Load all identified vol files into Outpost 2's memory.
-	void LoadVolFiles();
+	void Activate();
 
 private:
 	struct VolSearchEntry {

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -13,7 +13,7 @@ std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDire
 class VolList
 {
 public:
-	VolList() = default;
+	VolList();
 	VolList(std::vector<std::string> volPaths);
 
 	// Load all identified vol files into Outpost 2's memory.

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -4,6 +4,8 @@
 #include <vector>
 
 
+std::vector<std::string> operator+(std::vector<std::string> lhs, const std::vector<std::string>& rhs);
+
 std::vector<std::string> FindVolFilesInDirectory(const std::string& relativeDirectory);
 
 

--- a/srcStatic/VolList.h
+++ b/srcStatic/VolList.h
@@ -34,7 +34,7 @@ private:
 	};
 
 	const std::vector<std::string> volPaths;
-	std::vector<VolSearchEntry> volSearchEntryList;
+	const std::vector<VolSearchEntry> volSearchEntryList;
 
 	static std::vector<VolSearchEntry> CreateVolSearchEntryList(const std::vector<std::string>& volPaths);
 };

--- a/test/VolList.test.cpp
+++ b/test/VolList.test.cpp
@@ -14,6 +14,17 @@ TEST(VolList, VectorConcat)
 	EXPECT_EQ((Vec{"a"}), (Vec{"a"} + Vec{}));
 	EXPECT_EQ((Vec{"a", "b"}), (Vec{"a"} + Vec{"b"}));
 	EXPECT_EQ((Vec{"a", "b", "c", "d"}), (Vec{"a", "b"} + Vec{"c", "d"}));
+
+	// Temporary must be named to bind to non-const reference in operator overload
+	Vec namedTemp{"a", "b"};
+	EXPECT_EQ((Vec{"a", "b", "c", "d"}), (namedTemp += Vec{"c", "d"}));
+
+	// Ensure reference semantics are preserved (return type has &)
+	// Result of operator += is assignable and modifies the same value, not a copy
+	// Built in types such as int behave similarly
+	// (Example: int a = 0; (a += 10) = 100; assert(a == 100);)
+	EXPECT_EQ((Vec{"assigned value"}), (namedTemp += Vec{"overwritten"}) = Vec{"assigned value"});
+	EXPECT_EQ((Vec{"assigned value"}), namedTemp);
 }
 
 

--- a/test/VolList.test.cpp
+++ b/test/VolList.test.cpp
@@ -54,5 +54,4 @@ TEST(VolList, EmptyAdd)
 	VolList volList;
 
 	EXPECT_NO_THROW(volList.AddVolFile(""));
-	EXPECT_NO_THROW(volList.AddVolFilesFromDirectory(""));
 }

--- a/test/VolList.test.cpp
+++ b/test/VolList.test.cpp
@@ -49,9 +49,8 @@ TEST(VolList, FindVolFilesInDirectory)
 }
 
 
-TEST(VolList, EmptyAdd)
+TEST(VolList, EmptyList)
 {
+	// Ensure we can default construct an empty list
 	VolList volList;
-
-	EXPECT_NO_THROW(volList.AddVolFile(""));
 }

--- a/test/VolList.test.cpp
+++ b/test/VolList.test.cpp
@@ -5,6 +5,18 @@
 #include <fstream>
 
 
+TEST(VolList, VectorConcat)
+{
+	using Vec = std::vector<std::string>;
+
+	EXPECT_EQ((Vec{}), (Vec{} + Vec{}));
+	EXPECT_EQ((Vec{"a"}), (Vec{} + Vec{"a"}));
+	EXPECT_EQ((Vec{"a"}), (Vec{"a"} + Vec{}));
+	EXPECT_EQ((Vec{"a", "b"}), (Vec{"a"} + Vec{"b"}));
+	EXPECT_EQ((Vec{"a", "b", "c", "d"}), (Vec{"a", "b"} + Vec{"c", "d"}));
+}
+
+
 TEST(VolList, FindVolFilesInDirectory)
 {
 	using Vec = std::vector<std::string>;

--- a/test/VolList.test.cpp
+++ b/test/VolList.test.cpp
@@ -1,5 +1,29 @@
 #include "VolList.h"
+#include "FileSystemHelper.h"
+#include "FsInclude.h"
 #include <gtest/gtest.h>
+#include <fstream>
+
+
+TEST(VolList, FindVolFilesInDirectory)
+{
+	using Vec = std::vector<std::string>;
+
+	EXPECT_EQ((Vec{}), FindVolFilesInDirectory(""));
+	EXPECT_EQ((Vec{}), FindVolFilesInDirectory("NonExistentDirectory/"));
+
+	const auto volName1 = std::string("EmptyTestVolFile1.vol");
+	const auto volName2 = std::string("EmptyTestVolFile2.VOL");
+	const auto volPath1 = fs::path(GetExeDirectory()) / volName1;
+	const auto volPath2 = fs::path(GetExeDirectory()) / volName2;
+	std::ofstream(volPath1.string());
+	std::ofstream(volPath2.string());
+
+	EXPECT_EQ((Vec{volName1, volName2}), FindVolFilesInDirectory(""));
+
+	fs::remove(volPath1);
+	fs::remove(volPath2);
+}
 
 
 TEST(VolList, EmptyAdd)


### PR DESCRIPTION
This closes #239. This completes a big chunk of the background work needed to allow changing the loaded VOL list at arbitrary times.

----

The solution I used involved vector concatenation. It seems there is no convenient built in facility to do this, so custom operator overloads were added. For some interesting information on operator overloads, see:
https://stackoverflow.com/questions/4421706/what-are-the-basic-rules-and-idioms-for-operator-overloading
