### PR TITLE
Use `std::size_t` instead of `int` in OP2Memory

### DIFF
--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -59,7 +59,7 @@ bool Op2MemEdit(void* destBaseAddr, std::size_t size, Function memoryEditFunctio
 }
 
 
-bool Op2MemSet(void* destBaseAddr, unsigned char value, int size)
+bool Op2MemSet(void* destBaseAddr, unsigned char value, std::size_t size)
 {
 	return Op2MemEdit(
 		destBaseAddr,
@@ -68,7 +68,7 @@ bool Op2MemSet(void* destBaseAddr, unsigned char value, int size)
 	);
 }
 
-bool Op2MemCopy(void* destBaseAddr, const void* sourceAddr, int size)
+bool Op2MemCopy(void* destBaseAddr, const void* sourceAddr, std::size_t size)
 {
 	return Op2MemEdit(
 		destBaseAddr,
@@ -77,7 +77,7 @@ bool Op2MemCopy(void* destBaseAddr, const void* sourceAddr, int size)
 	);
 }
 
-bool Op2MemSetDword(void* destBaseAddr, int dword)
+bool Op2MemSetDword(void* destBaseAddr, std::size_t dword)
 {
 	return Op2MemCopy(destBaseAddr, &dword, sizeof(dword));
 }

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -8,9 +8,9 @@
 
 bool EnableOp2MemoryPatching();
 
-bool Op2MemCopy(void* destBaseAddr, const void* sourceAddr, int size);
-bool Op2MemSet(void* destBaseAddr, unsigned char value, int size);
-bool Op2MemSetDword(void* destBaseAddr, int dword);
+bool Op2MemCopy(void* destBaseAddr, const void* sourceAddr, std::size_t size);
+bool Op2MemSet(void* destBaseAddr, unsigned char value, std::size_t size);
+bool Op2MemSetDword(void* destBaseAddr, std::size_t dword);
 bool Op2MemSetDword(void* destBaseAddr, const void* dword);
 bool Op2RelinkCall(std::size_t callOffset, const void* newFunctionAddress);
 bool Op2UnprotectMemory(std::size_t destBaseAddr, std::size_t size);


### PR DESCRIPTION
Small fix I just happened to notice.
