### PR TITLE
`constexpr` updates

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -90,11 +90,12 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 bool InstallDepPatch()
 {
 	// Set the execute flag on the DSEG section so DEP doesn't terminate the game
-	constexpr std::size_t destinationBaseAddress = 0x00585000;
-	bool success = Op2UnprotectMemory(destinationBaseAddress, 0x00587000 - 0x00585000);
+	constexpr std::size_t dsegSectionBaseAddress = 0x00585000;
+	constexpr std::size_t dsegSectionSize = 0x00587000 - 0x00585000;
+	bool success = Op2UnprotectMemory(dsegSectionBaseAddress, dsegSectionSize);
 
 	if (!success) {
-		LogError("Error unprotecting memory at: 0x" + AddrToHexString(destinationBaseAddress));
+		LogError("Error unprotecting DSEG memory at: 0x" + AddrToHexString(dsegSectionBaseAddress));
 	}
 
 	return success;

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -90,7 +90,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 bool InstallDepPatch()
 {
 	// Set the execute flag on the DSEG section so DEP doesn't terminate the game
-	const std::size_t destinationBaseAddress = 0x00585000;
+	constexpr std::size_t destinationBaseAddress = 0x00585000;
 	bool success = Op2UnprotectMemory(destinationBaseAddress, 0x00587000 - 0x00585000);
 
 	if (!success) {

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -89,7 +89,7 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 	else {
 		char buffer[8];
 		_snprintf_s(buffer, sizeof(buffer), "%i.%i.%i.%i", major, minor, 0, patch);
-		const std::size_t multiplayerVersionStringAddress = 0x004E973C;
+		constexpr std::size_t multiplayerVersionStringAddress = 0x004E973C;
 		Op2MemCopy(multiplayerVersionStringAddress, buffer, sizeof(buffer));
 	}
 }

--- a/srcStatic/GameModules/IpDropDown.cpp
+++ b/srcStatic/GameModules/IpDropDown.cpp
@@ -16,11 +16,11 @@ char ipStrings[10][47];
 int numIpStrings = 0;
 
 // Data constants for InstallIpDropDown
-const auto newEnableWindowAddr = &EnableWindowNew;
-const auto newInetAddr = &inet_addrNew;
-const std::size_t populateComboBoxAddr = 0x004197C1;
-const std::size_t saveIpTextAddr = 0x004C0E36;
-const std::size_t nopDataAddr = 0x0041988F;
+constexpr auto newEnableWindowAddr = &EnableWindowNew;
+constexpr auto newInetAddr = &inet_addrNew;
+constexpr std::size_t populateComboBoxAddr = 0x004197C1;
+constexpr std::size_t saveIpTextAddr = 0x004C0E36;
+constexpr std::size_t nopDataAddr = 0x0041988F;
 
 
 IPDropDown::IPDropDown()

--- a/srcStatic/GameModules/IpDropDown.cpp
+++ b/srcStatic/GameModules/IpDropDown.cpp
@@ -15,12 +15,11 @@ void WriteAddressesToIniFile();
 char ipStrings[10][47];
 int numIpStrings = 0;
 
-// Data constants for InstallIpDropDown
+
+// New jump table entries for IpDropDown patch
+// These must have fixed long lived addresses (global)
 constexpr auto newEnableWindowAddr = &EnableWindowNew;
 constexpr auto newInetAddr = &inet_addrNew;
-constexpr std::size_t populateComboBoxAddr = 0x004197C1;
-constexpr std::size_t saveIpTextAddr = 0x004C0E36;
-constexpr std::size_t nopDataAddr = 0x0041988F;
 
 
 IPDropDown::IPDropDown()
@@ -30,6 +29,11 @@ IPDropDown::IPDropDown()
 
 void IPDropDown::Load()
 {
+	// IpDropDown patch locations
+	constexpr std::size_t populateComboBoxAddr = 0x004197C1;
+	constexpr std::size_t saveIpTextAddr = 0x004C0E36;
+	constexpr std::size_t nopDataAddr = 0x0041988F;
+
 	// patch the call to EnableWindow so we can add strings.
 	Op2MemSetDword(populateComboBoxAddr, &newEnableWindowAddr);
 	Op2MemSetDword(saveIpTextAddr, &newInetAddr);

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -7,7 +7,7 @@
 
 bool memoryPatchingEnabled = false;
 std::size_t loadOffset = 0;
-const std::size_t ExpectedOutpost2Addr = 0x00400000;
+constexpr std::size_t ExpectedOutpost2Addr = 0x00400000;
 
 
 // Enabled patching of Outpost2.exe memory

--- a/srcStatic/ResourceSearchPath.cpp
+++ b/srcStatic/ResourceSearchPath.cpp
@@ -67,7 +67,7 @@ bool ResourceSearchPath::CallOriginalGetFilePath(const char* resourceName, /* [o
 {
 	// Use Outpost2.exe's built in ResManager object, and its associated member function
 	ResManager& resManager = *reinterpret_cast<ResManager*>(0x56C028);
-	auto originalGetFilePath = GetMethodPointer<decltype(&ResManager::GetFilePath)>(0x00471590);
+	const auto originalGetFilePath = GetMethodPointer<decltype(&ResManager::GetFilePath)>(0x00471590);
 	return (resManager.*originalGetFilePath)(resourceName, filePath);
 }
 

--- a/srcStatic/ResourceSearchPath.cpp
+++ b/srcStatic/ResourceSearchPath.cpp
@@ -55,8 +55,7 @@ void ResourceSearchPath::HookFileSearchPath()
 		0x004977E4,
 	};
 	// Convert a pointer to member function to a regular `void*` value
-	auto getFilePath = &ResManager::GetFilePath;
-	const auto getFilePathAddr = GetMethodVoidPointer(getFilePath);
+	const auto getFilePathAddr = GetMethodVoidPointer(&ResManager::GetFilePath);
 
 	for (const auto callAddr : callsToGetFilePath) {
 		Op2RelinkCall(callAddr, getFilePathAddr);

--- a/test/OP2Memory.test.cpp
+++ b/test/OP2Memory.test.cpp
@@ -99,10 +99,10 @@ TEST_F(MethodPointerTest, PointerAddressPointerRoundTrip) {
 
 TEST_F(MethodPointerTest, GetMethodPointerUse) {
 	// Get fixed size_t address of member method (perhaps deduced by disassembler)
-	auto methodAddress = GetMethodAddress(&ExampleClass::ExampleMethod);
+	const auto methodAddress = GetMethodAddress(&ExampleClass::ExampleMethod);
 
 	// Cast the raw address back to a usable pointer
-	auto methodPointer = GetMethodPointer<MemberPointerType>(methodAddress);
+	const auto methodPointer = GetMethodPointer<MemberPointerType>(methodAddress);
 	// Make sure method pointer is usable on target object
 	EXPECT_EQ(2, (exampleObject.*methodPointer)(1));
 }

--- a/test/OP2Memory.test.cpp
+++ b/test/OP2Memory.test.cpp
@@ -24,7 +24,7 @@ protected:
 	static_assert(5 == sizeof(CallInstruction));
 
 	CallInstruction callInstruction = {CallOpcode, 0x00000000};
-	std::size_t callInstructionAddr = reinterpret_cast<std::size_t>(&callInstruction);
+	const std::size_t callInstructionAddr = reinterpret_cast<std::size_t>(&callInstruction);
 };
 
 


### PR DESCRIPTION
Most patches will be written with hardcoded `constexpr` values, so I went and marked them as such.

A few constants were moved into the methods that used them. New jump table entries that must remain long-lived at fixed addresses (such as global/static variables) were marked as such.
