### PR TITLE
Add `GetExportAddress` helper

### DIFF
--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -26,19 +26,19 @@ void DllModule::LoadModuleDll(const std::string& dllPath)
 
 void DllModule::DetectExportedModuleFunctions()
 {
-	loadModuleFunctionIni = reinterpret_cast<LoadModuleFunctionIni>(GetProcAddress(moduleDllHandle, "InitMod"));
+	loadModuleFunctionIni = GetExportAddress<LoadModuleFunctionIni>("InitMod");
 	if (loadModuleFunctionIni == nullptr) {
-		loadModuleFunctionConsole = reinterpret_cast<LoadModuleFunctionConsole>(GetProcAddress(moduleDllHandle, "mod_init"));
+		loadModuleFunctionConsole = GetExportAddress<LoadModuleFunctionConsole>("mod_init");
 	}
 
-	unloadModuleFunctionIni = reinterpret_cast<UnloadModuleFunctionIni>(GetProcAddress(moduleDllHandle, "DestroyMod"));
+	unloadModuleFunctionIni = GetExportAddress<UnloadModuleFunctionIni>("DestroyMod");
 	if (unloadModuleFunctionIni == nullptr) {
-		unloadModuleFunctionConsole = reinterpret_cast<UnloadModuleFunctionConsole>(GetProcAddress(moduleDllHandle, "mod_destroy"));
+		unloadModuleFunctionConsole = GetExportAddress<UnloadModuleFunctionConsole>("mod_destroy");
 	}
 
-	runModuleFunction = reinterpret_cast<RunModuleFunction>(GetProcAddress(moduleDllHandle, "RunMod"));
+	runModuleFunction = GetExportAddress<RunModuleFunction>("RunMod");
 	if (runModuleFunction == nullptr) {
-		runModuleFunction = reinterpret_cast<RunModuleFunction>(GetProcAddress(moduleDllHandle, "mod_run"));
+		runModuleFunction = GetExportAddress<RunModuleFunction>("mod_run");
 	}
 }
 

--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -12,7 +12,7 @@ void DllModule::LoadModuleDll(const std::string& dllPath)
 	// Try to load a DLL with the given name (possibly an empty string)
 	HINSTANCE dllHandle = LoadLibraryA(dllPath.c_str());
 
-	if (dllHandle == nullptr) {
+	if (!dllHandle) {
 		throw std::runtime_error(
 			"Unable to load DLL path: " + dllPath +
 			" LoadLibrary " + GetLastErrorString()
@@ -27,27 +27,27 @@ void DllModule::LoadModuleDll(const std::string& dllPath)
 void DllModule::DetectExportedModuleFunctions()
 {
 	loadModuleFunctionIni = GetExportAddress<LoadModuleFunctionIni>("InitMod");
-	if (loadModuleFunctionIni == nullptr) {
+	if (!loadModuleFunctionIni) {
 		loadModuleFunctionConsole = GetExportAddress<LoadModuleFunctionConsole>("mod_init");
 	}
 
 	unloadModuleFunctionIni = GetExportAddress<UnloadModuleFunctionIni>("DestroyMod");
-	if (unloadModuleFunctionIni == nullptr) {
+	if (!unloadModuleFunctionIni) {
 		unloadModuleFunctionConsole = GetExportAddress<UnloadModuleFunctionConsole>("mod_destroy");
 	}
 
 	runModuleFunction = GetExportAddress<RunModuleFunction>("RunMod");
-	if (runModuleFunction == nullptr) {
+	if (!runModuleFunction) {
 		runModuleFunction = GetExportAddress<RunModuleFunction>("mod_run");
 	}
 }
 
 void DllModule::Load()
 {
-	if (loadModuleFunctionIni != nullptr) {
+	if (loadModuleFunctionIni) {
 		loadModuleFunctionIni(Name().c_str());
 	}
-	else if (loadModuleFunctionConsole != nullptr) {
+	else if (loadModuleFunctionConsole) {
 		loadModuleFunctionConsole();
 	}
 }
@@ -56,17 +56,17 @@ bool DllModule::Unload()
 {
 	bool success = true;
 
-	if (unloadModuleFunctionIni != nullptr) {
+	if (unloadModuleFunctionIni) {
 		unloadModuleFunctionIni();
 	}
-	else if (unloadModuleFunctionConsole != nullptr) {
+	else if (unloadModuleFunctionConsole) {
 		success = unloadModuleFunctionConsole();
 		if (!success) {
 			LogMessage("Module reports error during unload: " + Name());
 		}
 	}
 
-	if (moduleDllHandle != nullptr) {
+	if (moduleDllHandle) {
 		FreeLibrary(moduleDllHandle);
 	}
 
@@ -75,7 +75,7 @@ bool DllModule::Unload()
 
 void DllModule::Run()
 {
-	if (runModuleFunction != nullptr) {
+	if (runModuleFunction) {
 		runModuleFunction();
 	}
 }

--- a/srcStatic/GameModules/DllModule.h
+++ b/srcStatic/GameModules/DllModule.h
@@ -3,6 +3,7 @@
 #include "../GameModule.h"
 #include <windows.h>
 #include <string>
+#include <type_traits>
 
 
 // External module that may contain hooks for a DLL
@@ -31,6 +32,12 @@ private:
 
 	// Search for dll's initialization, run & destroy functions
 	void DetectExportedModuleFunctions();
+
+	template <typename ExportType>
+	ExportType GetExportAddress(const char* exportName) {
+		static_assert(std::is_pointer<ExportType>::value, "Type must be a pointer");
+		return reinterpret_cast<ExportType>(GetProcAddress(moduleDllHandle, exportName));
+	}
 
 	LoadModuleFunctionIni loadModuleFunctionIni = nullptr;
 	LoadModuleFunctionConsole loadModuleFunctionConsole = nullptr;


### PR DESCRIPTION
This simplifies DLL function lookup.

This is passingly related to the suggestion for an RAII style object for DLL `HMODULE` handles from issue #195.
