### PR TITLE
Change pointer integer types to `uintptr_t`

### DIFF
--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -15,6 +15,7 @@
 #include <windows.h>
 #include <string>
 #include <cstddef>
+#include <cstdint>
 
 
 bool InstallDepPatch();

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -91,7 +91,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 bool InstallDepPatch()
 {
 	// Set the execute flag on the DSEG section so DEP doesn't terminate the game
-	constexpr std::size_t dsegSectionBaseAddress = 0x00585000;
+	constexpr uintptr_t dsegSectionBaseAddress = 0x00585000;
 	constexpr std::size_t dsegSectionSize = 0x00587000 - 0x00585000;
 	bool success = Op2UnprotectMemory(dsegSectionBaseAddress, dsegSectionSize);
 

--- a/srcDLL/DllMain.cpp
+++ b/srcDLL/DllMain.cpp
@@ -91,7 +91,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD dwReason, LPVOID reserved)
 bool InstallDepPatch()
 {
 	// Set the execute flag on the DSEG section so DEP doesn't terminate the game
-	constexpr uintptr_t dsegSectionBaseAddress = 0x00585000;
+	constexpr std::uintptr_t dsegSectionBaseAddress = 0x00585000;
 	constexpr std::size_t dsegSectionSize = 0x00587000 - 0x00585000;
 	bool success = Op2UnprotectMemory(dsegSectionBaseAddress, dsegSectionSize);
 

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -84,7 +84,7 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 	else {
 		char buffer[8];
 		_snprintf_s(buffer, sizeof(buffer), "%i.%i.%i.%i", major, minor, 0, patch);
-		constexpr uintptr_t multiplayerVersionStringAddress = 0x004E973C;
+		constexpr std::uintptr_t multiplayerVersionStringAddress = 0x004E973C;
 		Op2MemCopy(multiplayerVersionStringAddress, buffer, sizeof(buffer));
 	}
 }

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -10,6 +10,7 @@
 #include <exception>
 #include <string>
 #include <cstddef>
+#include <cstdint>
 
 
 // Dummy export for linking requirements from Outpost2.exe and OP2Shell.dll.

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -90,7 +90,7 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 	else {
 		char buffer[8];
 		_snprintf_s(buffer, sizeof(buffer), "%i.%i.%i.%i", major, minor, 0, patch);
-		constexpr std::size_t multiplayerVersionStringAddress = 0x004E973C;
+		constexpr uintptr_t multiplayerVersionStringAddress = 0x004E973C;
 		Op2MemCopy(multiplayerVersionStringAddress, buffer, sizeof(buffer));
 	}
 }

--- a/srcStatic/GameModules/IpDropDown.cpp
+++ b/srcStatic/GameModules/IpDropDown.cpp
@@ -7,6 +7,7 @@
 #include <windows.h>
 #include <string>
 #include <cstddef>
+#include <cstdint>
 
 
 BOOL __stdcall EnableWindowNew(HWND hWnd, BOOL bEnable);

--- a/srcStatic/GameModules/IpDropDown.cpp
+++ b/srcStatic/GameModules/IpDropDown.cpp
@@ -31,9 +31,9 @@ IPDropDown::IPDropDown()
 void IPDropDown::Load()
 {
 	// IpDropDown patch locations
-	constexpr std::size_t populateComboBoxAddr = 0x004197C1;
-	constexpr std::size_t saveIpTextAddr = 0x004C0E36;
-	constexpr std::size_t nopDataAddr = 0x0041988F;
+	constexpr uintptr_t populateComboBoxAddr = 0x004197C1;
+	constexpr uintptr_t saveIpTextAddr = 0x004C0E36;
+	constexpr uintptr_t nopDataAddr = 0x0041988F;
 
 	// patch the call to EnableWindow so we can add strings.
 	Op2MemSetDword(populateComboBoxAddr, &newEnableWindowAddr);

--- a/srcStatic/GameModules/IpDropDown.cpp
+++ b/srcStatic/GameModules/IpDropDown.cpp
@@ -31,9 +31,9 @@ IPDropDown::IPDropDown()
 void IPDropDown::Load()
 {
 	// IpDropDown patch locations
-	constexpr uintptr_t populateComboBoxAddr = 0x004197C1;
-	constexpr uintptr_t saveIpTextAddr = 0x004C0E36;
-	constexpr uintptr_t nopDataAddr = 0x0041988F;
+	constexpr std::uintptr_t populateComboBoxAddr = 0x004197C1;
+	constexpr std::uintptr_t saveIpTextAddr = 0x004C0E36;
+	constexpr std::uintptr_t nopDataAddr = 0x0041988F;
 
 	// patch the call to EnableWindow so we can add strings.
 	Op2MemSetDword(populateComboBoxAddr, &newEnableWindowAddr);

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -6,8 +6,8 @@
 
 
 bool memoryPatchingEnabled = false;
-uintptr_t loadOffset = 0;
-constexpr uintptr_t ExpectedOutpost2Addr = 0x00400000;
+std::uintptr_t loadOffset = 0;
+constexpr std::uintptr_t ExpectedOutpost2Addr = 0x00400000;
 
 
 // Enabled patching of Outpost2.exe memory
@@ -27,13 +27,13 @@ bool EnableOp2MemoryPatching()
 
 	// Enable memory patching for Outpost2.exe, and set relocation offset
 	memoryPatchingEnabled = true;
-	loadOffset = reinterpret_cast<uintptr_t>(op2ModuleBase) - ExpectedOutpost2Addr;
+	loadOffset = reinterpret_cast<std::uintptr_t>(op2ModuleBase) - ExpectedOutpost2Addr;
 	return true;
 }
 
 
 template <typename Function>
-bool Op2MemEdit(uintptr_t destBaseAddr, std::size_t size, Function memoryEditFunction)
+bool Op2MemEdit(std::uintptr_t destBaseAddr, std::size_t size, Function memoryEditFunction)
 {
 	if (!memoryPatchingEnabled) {
 		return false;
@@ -59,7 +59,7 @@ bool Op2MemEdit(uintptr_t destBaseAddr, std::size_t size, Function memoryEditFun
 }
 
 
-bool Op2MemSet(uintptr_t destBaseAddr, unsigned char value, std::size_t size)
+bool Op2MemSet(std::uintptr_t destBaseAddr, unsigned char value, std::size_t size)
 {
 	return Op2MemEdit(
 		destBaseAddr,
@@ -68,7 +68,7 @@ bool Op2MemSet(uintptr_t destBaseAddr, unsigned char value, std::size_t size)
 	);
 }
 
-bool Op2MemCopy(uintptr_t destBaseAddr, const void* sourceAddr, std::size_t size)
+bool Op2MemCopy(std::uintptr_t destBaseAddr, const void* sourceAddr, std::size_t size)
 {
 	return Op2MemEdit(
 		destBaseAddr,
@@ -77,12 +77,12 @@ bool Op2MemCopy(uintptr_t destBaseAddr, const void* sourceAddr, std::size_t size
 	);
 }
 
-bool Op2MemSetDword(uintptr_t destBaseAddr, std::size_t dword)
+bool Op2MemSetDword(std::uintptr_t destBaseAddr, std::size_t dword)
 {
 	return Op2MemCopy(destBaseAddr, &dword, sizeof(dword));
 }
 
-bool Op2MemSetDword(uintptr_t destBaseAddr, const void* dword)
+bool Op2MemSetDword(std::uintptr_t destBaseAddr, const void* dword)
 {
 	return Op2MemCopy(destBaseAddr, &dword, sizeof(dword));
 }
@@ -93,7 +93,7 @@ bool Op2MemSetDword(uintptr_t destBaseAddr, const void* dword)
 //   CALL someMethod  ; Encoded as E8 00040000
 //   postCallInstruction:
 // The `callOffset` parameter is the address of the encoded DWORD
-bool Op2RelinkCall(uintptr_t callOffset, const void* newFunctionAddress)
+bool Op2RelinkCall(std::uintptr_t callOffset, const void* newFunctionAddress)
 {
 	if (!memoryPatchingEnabled) {
 		return false;
@@ -110,7 +110,7 @@ bool Op2RelinkCall(uintptr_t callOffset, const void* newFunctionAddress)
 }
 
 
-bool Op2UnprotectMemory(uintptr_t destBaseAddr, std::size_t size)
+bool Op2UnprotectMemory(std::uintptr_t destBaseAddr, std::size_t size)
 {
 	if (!memoryPatchingEnabled) {
 		return false;

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -45,7 +45,7 @@ bool Op2MemEdit(uintptr_t destBaseAddr, std::size_t size, Function memoryEditFun
 	DWORD oldAttr;
 	BOOL bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
 	if (!bSuccess) {
-		LogError("Error unprotecting memory at: 0x" + AddrToHexString(reinterpret_cast<uintptr_t>(destAddr)) + ".");
+		LogError("Error unprotecting memory at: 0x" + AddrToHexString(destAddr) + ".");
 		return false;
 	}
 

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -6,8 +6,8 @@
 
 
 bool memoryPatchingEnabled = false;
-std::size_t loadOffset = 0;
-constexpr std::size_t ExpectedOutpost2Addr = 0x00400000;
+uintptr_t loadOffset = 0;
+constexpr uintptr_t ExpectedOutpost2Addr = 0x00400000;
 
 
 // Enabled patching of Outpost2.exe memory
@@ -27,13 +27,13 @@ bool EnableOp2MemoryPatching()
 
 	// Enable memory patching for Outpost2.exe, and set relocation offset
 	memoryPatchingEnabled = true;
-	loadOffset = reinterpret_cast<std::size_t>(op2ModuleBase) - ExpectedOutpost2Addr;
+	loadOffset = reinterpret_cast<uintptr_t>(op2ModuleBase) - ExpectedOutpost2Addr;
 	return true;
 }
 
 
 template <typename Function>
-bool Op2MemEdit(std::size_t destBaseAddr, std::size_t size, Function memoryEditFunction)
+bool Op2MemEdit(uintptr_t destBaseAddr, std::size_t size, Function memoryEditFunction)
 {
 	if (!memoryPatchingEnabled) {
 		return false;
@@ -45,7 +45,7 @@ bool Op2MemEdit(std::size_t destBaseAddr, std::size_t size, Function memoryEditF
 	DWORD oldAttr;
 	BOOL bSuccess = VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
 	if (!bSuccess) {
-		LogError("Error unprotecting memory at: 0x" + AddrToHexString(reinterpret_cast<std::size_t>(destAddr)) + ".");
+		LogError("Error unprotecting memory at: 0x" + AddrToHexString(reinterpret_cast<uintptr_t>(destAddr)) + ".");
 		return false;
 	}
 
@@ -59,7 +59,7 @@ bool Op2MemEdit(std::size_t destBaseAddr, std::size_t size, Function memoryEditF
 }
 
 
-bool Op2MemSet(std::size_t destBaseAddr, unsigned char value, std::size_t size)
+bool Op2MemSet(uintptr_t destBaseAddr, unsigned char value, std::size_t size)
 {
 	return Op2MemEdit(
 		destBaseAddr,
@@ -68,7 +68,7 @@ bool Op2MemSet(std::size_t destBaseAddr, unsigned char value, std::size_t size)
 	);
 }
 
-bool Op2MemCopy(std::size_t destBaseAddr, const void* sourceAddr, std::size_t size)
+bool Op2MemCopy(uintptr_t destBaseAddr, const void* sourceAddr, std::size_t size)
 {
 	return Op2MemEdit(
 		destBaseAddr,
@@ -77,12 +77,12 @@ bool Op2MemCopy(std::size_t destBaseAddr, const void* sourceAddr, std::size_t si
 	);
 }
 
-bool Op2MemSetDword(std::size_t destBaseAddr, std::size_t dword)
+bool Op2MemSetDword(uintptr_t destBaseAddr, std::size_t dword)
 {
 	return Op2MemCopy(destBaseAddr, &dword, sizeof(dword));
 }
 
-bool Op2MemSetDword(std::size_t destBaseAddr, const void* dword)
+bool Op2MemSetDword(uintptr_t destBaseAddr, const void* dword)
 {
 	return Op2MemCopy(destBaseAddr, &dword, sizeof(dword));
 }
@@ -93,7 +93,7 @@ bool Op2MemSetDword(std::size_t destBaseAddr, const void* dword)
 //   CALL someMethod  ; Encoded as E8 00040000
 //   postCallInstruction:
 // The `callOffset` parameter is the address of the encoded DWORD
-bool Op2RelinkCall(std::size_t callOffset, const void* newFunctionAddress)
+bool Op2RelinkCall(uintptr_t callOffset, const void* newFunctionAddress)
 {
 	if (!memoryPatchingEnabled) {
 		return false;
@@ -110,7 +110,7 @@ bool Op2RelinkCall(std::size_t callOffset, const void* newFunctionAddress)
 }
 
 
-bool Op2UnprotectMemory(std::size_t destBaseAddr, std::size_t size)
+bool Op2UnprotectMemory(uintptr_t destBaseAddr, std::size_t size)
 {
 	if (!memoryPatchingEnabled) {
 		return false;

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -3,23 +3,24 @@
 #pragma once
 
 #include <cstddef>
+#include <cstdint>
 #include <type_traits>
 
 
 bool EnableOp2MemoryPatching();
 
-bool Op2MemCopy(std::size_t destBaseAddr, const void* sourceAddr, std::size_t size);
-bool Op2MemSet(std::size_t destBaseAddr, unsigned char value, std::size_t size);
-bool Op2MemSetDword(std::size_t destBaseAddr, std::size_t dword);
-bool Op2MemSetDword(std::size_t destBaseAddr, const void* dword);
-bool Op2RelinkCall(std::size_t callOffset, const void* newFunctionAddress);
-bool Op2UnprotectMemory(std::size_t destBaseAddr, std::size_t size);
+bool Op2MemCopy(uintptr_t destBaseAddr, const void* sourceAddr, std::size_t size);
+bool Op2MemSet(uintptr_t destBaseAddr, unsigned char value, std::size_t size);
+bool Op2MemSetDword(uintptr_t destBaseAddr, std::size_t dword);
+bool Op2MemSetDword(uintptr_t destBaseAddr, const void* dword);
+bool Op2RelinkCall(uintptr_t callOffset, const void* newFunctionAddress);
+bool Op2UnprotectMemory(uintptr_t destBaseAddr, std::size_t size);
 
 
 template <typename MethodPointerType>
-constexpr std::size_t GetMethodAddress(MethodPointerType methodPointer) {
+constexpr uintptr_t GetMethodAddress(MethodPointerType methodPointer) {
 	static_assert(std::is_member_function_pointer_v<MethodPointerType>, "Type must be member function pointer");
-	return reinterpret_cast<std::size_t>(GetMethodVoidPointer(methodPointer));
+	return reinterpret_cast<uintptr_t>(GetMethodVoidPointer(methodPointer));
 }
 
 template <typename MethodPointerType>
@@ -29,7 +30,7 @@ constexpr void* GetMethodVoidPointer(MethodPointerType methodPointer) {
 }
 
 template <typename MethodPointerType>
-constexpr MethodPointerType GetMethodPointer(std::size_t methodAddress) {
+constexpr MethodPointerType GetMethodPointer(uintptr_t methodAddress) {
 	static_assert(std::is_member_function_pointer_v<MethodPointerType>, "Type must be member function pointer");
 	auto methodVoidPointer = reinterpret_cast<void*>(methodAddress);
 
@@ -39,7 +40,7 @@ constexpr MethodPointerType GetMethodPointer(std::size_t methodAddress) {
 	union MethodPointerUnion {
 		MethodPointerType pointer;
 		struct {
-			std::size_t address;
+			uintptr_t address;
 			std::size_t thisOffset;
 		};
 

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -9,18 +9,18 @@
 
 bool EnableOp2MemoryPatching();
 
-bool Op2MemCopy(uintptr_t destBaseAddr, const void* sourceAddr, std::size_t size);
-bool Op2MemSet(uintptr_t destBaseAddr, unsigned char value, std::size_t size);
-bool Op2MemSetDword(uintptr_t destBaseAddr, std::size_t dword);
-bool Op2MemSetDword(uintptr_t destBaseAddr, const void* dword);
-bool Op2RelinkCall(uintptr_t callOffset, const void* newFunctionAddress);
-bool Op2UnprotectMemory(uintptr_t destBaseAddr, std::size_t size);
+bool Op2MemCopy(std::uintptr_t destBaseAddr, const void* sourceAddr, std::size_t size);
+bool Op2MemSet(std::uintptr_t destBaseAddr, unsigned char value, std::size_t size);
+bool Op2MemSetDword(std::uintptr_t destBaseAddr, std::size_t dword);
+bool Op2MemSetDword(std::uintptr_t destBaseAddr, const void* dword);
+bool Op2RelinkCall(std::uintptr_t callOffset, const void* newFunctionAddress);
+bool Op2UnprotectMemory(std::uintptr_t destBaseAddr, std::size_t size);
 
 
 template <typename MethodPointerType>
-constexpr uintptr_t GetMethodAddress(MethodPointerType methodPointer) {
+constexpr std::uintptr_t GetMethodAddress(MethodPointerType methodPointer) {
 	static_assert(std::is_member_function_pointer_v<MethodPointerType>, "Type must be member function pointer");
-	return reinterpret_cast<uintptr_t>(GetMethodVoidPointer(methodPointer));
+	return reinterpret_cast<std::uintptr_t>(GetMethodVoidPointer(methodPointer));
 }
 
 template <typename MethodPointerType>
@@ -30,7 +30,7 @@ constexpr void* GetMethodVoidPointer(MethodPointerType methodPointer) {
 }
 
 template <typename MethodPointerType>
-constexpr MethodPointerType GetMethodPointer(uintptr_t methodAddress) {
+constexpr MethodPointerType GetMethodPointer(std::uintptr_t methodAddress) {
 	static_assert(std::is_member_function_pointer_v<MethodPointerType>, "Type must be member function pointer");
 	auto methodVoidPointer = reinterpret_cast<void*>(methodAddress);
 
@@ -40,7 +40,7 @@ constexpr MethodPointerType GetMethodPointer(uintptr_t methodAddress) {
 	union MethodPointerUnion {
 		MethodPointerType pointer;
 		struct {
-			uintptr_t address;
+			std::uintptr_t address;
 			std::size_t thisOffset;
 		};
 

--- a/srcStatic/ResourceSearchPath.cpp
+++ b/srcStatic/ResourceSearchPath.cpp
@@ -38,7 +38,7 @@ std::vector<std::string>& ResourceSearchPath::ModuleDirectories()
 
 void ResourceSearchPath::HookFileSearchPath()
 {
-	const std::vector<std::size_t> callsToGetFilePath{
+	const std::vector<uintptr_t> callsToGetFilePath{
 		0x00402E4B,
 		0x004038A9,
 		0x0045003C,

--- a/srcStatic/ResourceSearchPath.cpp
+++ b/srcStatic/ResourceSearchPath.cpp
@@ -38,7 +38,7 @@ std::vector<std::string>& ResourceSearchPath::ModuleDirectories()
 
 void ResourceSearchPath::HookFileSearchPath()
 {
-	const std::vector<uintptr_t> callsToGetFilePath{
+	const std::vector<std::uintptr_t> callsToGetFilePath{
 		0x00402E4B,
 		0x004038A9,
 		0x0045003C,

--- a/srcStatic/ResourceSearchPath.cpp
+++ b/srcStatic/ResourceSearchPath.cpp
@@ -5,6 +5,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #include <cstddef>
+#include <cstdint>
 
 
 // For compatibility with Outpost2.exe's built in class

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -65,7 +65,7 @@ std::string ToLower(std::string x) {
 }
 
 
-std::string AddrToHexString(std::size_t addr)
+std::string AddrToHexString(uintptr_t addr)
 {
 	std::ostringstream stringStream;
 	stringStream << std::setfill('0') << std::setw(8) << std::hex << addr;

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -65,7 +65,7 @@ std::string ToLower(std::string x) {
 }
 
 
-std::string AddrToHexString(uintptr_t addr)
+std::string AddrToHexString(std::uintptr_t addr)
 {
 	std::ostringstream stringStream;
 	stringStream << std::setfill('0') << std::setw(8) << std::hex << addr;
@@ -74,7 +74,7 @@ std::string AddrToHexString(uintptr_t addr)
 
 std::string AddrToHexString(const void* addr)
 {
-	return AddrToHexString(reinterpret_cast<uintptr_t>(addr));
+	return AddrToHexString(reinterpret_cast<std::uintptr_t>(addr));
 }
 
 

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -4,6 +4,7 @@
 #include <string_view>
 #include <vector>
 #include <cstddef>
+#include <cstdint>
 
 
 // Wraps either a narrow or wide raw string into either a std::string or std::wstring

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -32,7 +32,7 @@ std::string ToLower(std::string x);
 
 
 // Convert hex address value to string
-std::string AddrToHexString(uintptr_t addr);
+std::string AddrToHexString(std::uintptr_t addr);
 std::string AddrToHexString(const void* addr);
 
 

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -32,7 +32,7 @@ std::string ToLower(std::string x);
 
 
 // Convert hex address value to string
-std::string AddrToHexString(std::size_t addr);
+std::string AddrToHexString(uintptr_t addr);
 
 
 // Gets UTC date/time string using the system clock

--- a/srcStatic/WindowsUniqueHandle.h
+++ b/srcStatic/WindowsUniqueHandle.h
@@ -7,8 +7,8 @@
 // Unfortunately INVALID_HANDLE_VALUE is a macro containing a cast
 // The cast is equivalent to a reinterpret_cast, which makes it non-constexpr
 // As such, INVALID_HANDLE_VALUE can't be used as a non-type template parameter
-// Instead of HANDLE, use uintptr_t and an internal cast as a workaround
-template <uintptr_t nullValue>
+// Instead of HANDLE, use std::uintptr_t and an internal cast as a workaround
+template <std::uintptr_t nullValue>
 struct HandleDeleter {
 	using pointer = HANDLE;
 
@@ -21,7 +21,7 @@ struct HandleDeleter {
 
 
 // Like unique_ptr, but with some overrides to account for custom nullValue
-template <uintptr_t nullValue>
+template <std::uintptr_t nullValue>
 class UniqueHandle : public std::unique_ptr<HANDLE, HandleDeleter<nullValue>> {
 	using base = std::unique_ptr<HANDLE, HandleDeleter<nullValue>>;
 public:

--- a/srcStatic/WindowsUniqueHandle.h
+++ b/srcStatic/WindowsUniqueHandle.h
@@ -1,5 +1,6 @@
 #include <windows.h>
 #include <memory>
+#include <cstdint>
 
 
 // Sentinel value guarded HANDLE deleter

--- a/test/OP2Memory.test.cpp
+++ b/test/OP2Memory.test.cpp
@@ -24,7 +24,7 @@ protected:
 	static_assert(5 == sizeof(CallInstruction));
 
 	CallInstruction callInstruction = {CallOpcode, 0x00000000};
-	const std::size_t callInstructionAddr = reinterpret_cast<std::size_t>(&callInstruction);
+	const uintptr_t callInstructionAddr = reinterpret_cast<uintptr_t>(&callInstruction);
 };
 
 

--- a/test/OP2Memory.test.cpp
+++ b/test/OP2Memory.test.cpp
@@ -24,7 +24,7 @@ protected:
 	static_assert(5 == sizeof(CallInstruction));
 
 	CallInstruction callInstruction = {CallOpcode, 0x00000000};
-	const uintptr_t callInstructionAddr = reinterpret_cast<uintptr_t>(&callInstruction);
+	const std::uintptr_t callInstructionAddr = reinterpret_cast<std::uintptr_t>(&callInstruction);
 };
 
 


### PR DESCRIPTION
I recently came across a few sources that point to the subtle distinction between `std::size_t` and `uintptr_t`. It seems some of our uses of `std::size_t` are perhaps more accurately handled by the `uintptr_t` type.

Technically pointers to objects and maximum size of objects can be two different types with two different sizes. It just so happens that in today's typical flat memory models, the two types coincide. Previously, on segmented memory models, this was not the case. For 16-bit x86 real mode programming, object size might be restricted to a 16-bit segment, while an address might include both a segment and an offset, resulting in a 32-bit pointer. Future architectures are similarly not restricted to have matching types/sizes.

Reference:
[Fixed width integer types](https://en.cppreference.com/w/c/types/integer)  (C99, included by C++11)
[What is uintptr_t data type](https://stackoverflow.com/questions/1845482/what-is-uintptr-t-data-type)

There are likely other instances throughout the project that could be updated.
