### PR TITLE
Update module lookup

### DIFF
--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -7,15 +7,9 @@
 #include "WindowsModule.h"
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#include <intrin.h> // _ReturnAddress
 #include <exception>
 #include <string>
 #include <cstddef>
-
-#pragma intrinsic(_ReturnAddress)
-#ifdef __MINGW32__
-#define _ReturnAddress() __builtin_return_address(0)
-#endif
 
 
 // Dummy export for linking requirements from Outpost2.exe and OP2Shell.dll.

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -105,7 +105,12 @@ OP2EXT_API void Log(const char* message)
 	// These optimizations are however extremely unlikely when making
 	// calls across a module boundary (such as to exported methods).
 
-	LogMessage(FormatLogMessage(message, FindModuleName(_ReturnAddress())));
+	try {
+		LogMessage(FormatLogMessage(message, FindModuleName(_ReturnAddress())));
+	} catch(const std::exception& e) {
+		LogMessage("Error attempting to Log message from module. Return address to module is: " + AddrToHexString(_ReturnAddress()) + "  Error: " + e.what());
+		LogMessage(FormatLogMessage(message, "<UnknownModule>"));
+	}
 }
 
 

--- a/srcStatic/StringConversion.cpp
+++ b/srcStatic/StringConversion.cpp
@@ -72,6 +72,11 @@ std::string AddrToHexString(std::size_t addr)
 	return stringStream.str();
 }
 
+std::string AddrToHexString(const void* addr)
+{
+	return AddrToHexString(reinterpret_cast<std::size_t>(addr));
+}
+
 
 std::string GetDateTime()
 {

--- a/srcStatic/StringConversion.h
+++ b/srcStatic/StringConversion.h
@@ -33,6 +33,7 @@ std::string ToLower(std::string x);
 
 // Convert hex address value to string
 std::string AddrToHexString(std::size_t addr);
+std::string AddrToHexString(const void* addr);
 
 
 // Gets UTC date/time string using the system clock

--- a/srcStatic/WindowsModule.cpp
+++ b/srcStatic/WindowsModule.cpp
@@ -11,17 +11,23 @@
 #include "WindowsUniqueHandle.h"
 
 
+MODULEENTRY32 FindModuleEntry(const void* address);
 MODULEENTRY32 FindModuleEntry(HANDLE hModuleSnap, const void* address);
 bool containsAddress(MODULEENTRY32 const& moduleEntry, const void* address);
 
 
 std::string FindModuleName(const void* address) {
+	return std::string(FindModuleEntry(address).szModule);
+}
+
+
+MODULEENTRY32 FindModuleEntry(const void* address) {
 	// Get all modules for current process (processId can be 0)
 	UniqueHandleOrInvalid hModuleSnap{CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0)};
 	if (!hModuleSnap) {
 		throw std::runtime_error("Unable to create module snapshot");
 	}
-	return std::string(FindModuleEntry(hModuleSnap.get(), address).szModule);
+	return FindModuleEntry(hModuleSnap.get(), address);
 }
 
 MODULEENTRY32 FindModuleEntry(HANDLE hModuleSnap, const void* address) {

--- a/srcStatic/WindowsModule.cpp
+++ b/srcStatic/WindowsModule.cpp
@@ -21,8 +21,9 @@ std::string FindModuleName(const void* address) {
 }
 
 
+// Find module that contains the given address
 MODULEENTRY32 FindModuleEntry(const void* address) {
-	// Get all modules for current process (processId can be 0)
+	// Get all modules for current process (processId of 0 means current process)
 	UniqueHandleOrInvalid hModuleSnap{CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0)};
 	if (!hModuleSnap) {
 		throw std::runtime_error("Unable to create module snapshot");
@@ -30,6 +31,7 @@ MODULEENTRY32 FindModuleEntry(const void* address) {
 	return FindModuleEntry(hModuleSnap.get(), address);
 }
 
+// Find module from snapshot that contains the given address
 MODULEENTRY32 FindModuleEntry(HANDLE hModuleSnap, const void* address) {
 	MODULEENTRY32 moduleEntry;
 	moduleEntry.dwSize = sizeof(moduleEntry);
@@ -44,6 +46,7 @@ MODULEENTRY32 FindModuleEntry(HANDLE hModuleSnap, const void* address) {
 	throw std::runtime_error("Module lookup failed");
 }
 
+// Check if module entry address bounds contains the given address
 bool containsAddress(const MODULEENTRY32& moduleEntry, const void* address) {
 	return
 		(moduleEntry.modBaseAddr <= address) &&

--- a/srcStatic/WindowsModule.cpp
+++ b/srcStatic/WindowsModule.cpp
@@ -19,7 +19,7 @@ std::string FindModuleName(const void* address) {
 	// Get all modules for current process (processId can be 0)
 	UniqueHandleOrInvalid hModuleSnap{CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0)};
 	if (!hModuleSnap) {
-		return std::string("<Unable to create module snapshot>");
+		throw std::runtime_error("Unable to create module snapshot");
 	}
 	return FindModuleName(hModuleSnap.get(), address);
 }
@@ -33,9 +33,9 @@ std::string FindModuleName(HANDLE hModuleSnap, const void* address) {
 				return std::string(moduleEntry.szModule);
 			}
 		} while(Module32Next(hModuleSnap, &moduleEntry));
-		return std::string("<Module not found>");
+		throw std::runtime_error("Module not found");
 	}
-	return std::string("<Module lookup failed>");
+	throw std::runtime_error("Module lookup failed");
 }
 
 bool containsAddress(const MODULEENTRY32& moduleEntry, const void* address) {

--- a/srcStatic/WindowsModule.cpp
+++ b/srcStatic/WindowsModule.cpp
@@ -11,7 +11,7 @@
 #include "WindowsUniqueHandle.h"
 
 
-std::string FindModuleName(HANDLE hModuleSnap, const void* address);
+MODULEENTRY32 FindModuleEntry(HANDLE hModuleSnap, const void* address);
 bool containsAddress(MODULEENTRY32 const& moduleEntry, const void* address);
 
 
@@ -21,16 +21,16 @@ std::string FindModuleName(const void* address) {
 	if (!hModuleSnap) {
 		throw std::runtime_error("Unable to create module snapshot");
 	}
-	return FindModuleName(hModuleSnap.get(), address);
+	return std::string(FindModuleEntry(hModuleSnap.get(), address).szModule);
 }
 
-std::string FindModuleName(HANDLE hModuleSnap, const void* address) {
+MODULEENTRY32 FindModuleEntry(HANDLE hModuleSnap, const void* address) {
 	MODULEENTRY32 moduleEntry;
 	moduleEntry.dwSize = sizeof(moduleEntry);
 	if (Module32First(hModuleSnap, &moduleEntry)) {
 		do {
 			if (containsAddress(moduleEntry, address)) {
-				return std::string(moduleEntry.szModule);
+				return moduleEntry;
 			}
 		} while(Module32Next(hModuleSnap, &moduleEntry));
 		throw std::runtime_error("Module not found");

--- a/srcStatic/WindowsModule.h
+++ b/srcStatic/WindowsModule.h
@@ -1,6 +1,13 @@
 #pragma once
 
 #include <string>
+#include <intrin.h> // _ReturnAddress
+
+
+#pragma intrinsic(_ReturnAddress)
+#ifdef __MINGW32__
+#define _ReturnAddress() __builtin_return_address(0)
+#endif
 
 
 // Finds the module which contains the given address

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -111,7 +111,7 @@ TEST(StringConversion, ToLowerInPlace)
 }
 
 
-TEST(StringConversion, AddrToHexString)
+TEST(StringConversion, AddrToHexStringInt)
 {
 	// Correctly pads with 0
 	EXPECT_EQ("00000000", AddrToHexString(0u));
@@ -119,6 +119,15 @@ TEST(StringConversion, AddrToHexString)
 	// Note casing of hex values
 	EXPECT_EQ("deadbeef", AddrToHexString(0xDEADBEEF));
 }
+
+TEST(StringConversion, AddrToHexStringPtr)
+{
+	// Correctly pads with 0
+	EXPECT_EQ("00000000", AddrToHexString(nullptr));
+	// Note casing of hex values
+	EXPECT_EQ("deadbeef", AddrToHexString(reinterpret_cast<const void*>(0xDEADBEEF)));
+}
+
 
 TEST(StringConversion, GetDateTime)
 {

--- a/test/StringConversion.test.cpp
+++ b/test/StringConversion.test.cpp
@@ -114,8 +114,8 @@ TEST(StringConversion, ToLowerInPlace)
 TEST(StringConversion, AddrToHexString)
 {
 	// Correctly pads with 0
-	EXPECT_EQ("00000000", AddrToHexString(0));
-	EXPECT_EQ("00000000", AddrToHexString(00000000));
+	EXPECT_EQ("00000000", AddrToHexString(0u));
+	EXPECT_EQ("00000000", AddrToHexString(00000000u));
 	// Note casing of hex values
 	EXPECT_EQ("deadbeef", AddrToHexString(0xDEADBEEF));
 }

--- a/test/WindowsModule.test.cpp
+++ b/test/WindowsModule.test.cpp
@@ -1,0 +1,8 @@
+#include "WindowsModule.h"
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+
+TEST(WindowsModule, FindModuleName) {
+	EXPECT_THAT(FindModuleName(_ReturnAddress()), ::testing::EndsWith(".exe"));
+}

--- a/test/test.vcxproj
+++ b/test/test.vcxproj
@@ -39,6 +39,7 @@
     <ClCompile Include="OP2Memory.test.cpp" />
     <ClCompile Include="StringConversion.test.cpp" />
     <ClCompile Include="VolList.test.cpp" />
+    <ClCompile Include="WindowsModule.test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\srcStatic\op2extStatic.vcxproj">


### PR DESCRIPTION
This is some background cleanup work to support issue #186.

This generalizes the module lookup code so it can more easily be reused to lookup a module handle, rather than just a module name. (Looking up a module handle is not yet implemented).

Included is moving `_ReturnAddress` to WindowsModule.h.
