### PR TITLE
Add `UniqueModule`

### DIFF
--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -10,16 +10,14 @@ DllModule::DllModule(const std::string& moduleName)
 void DllModule::LoadModuleDll(const std::string& dllPath)
 {
 	// Try to load a DLL with the given name (possibly an empty string)
-	HINSTANCE dllHandle = LoadLibraryA(dllPath.c_str());
+	moduleDllHandle.reset(LoadLibraryA(dllPath.c_str()));
 
-	if (!dllHandle) {
+	if (!moduleDllHandle) {
 		throw std::runtime_error(
 			"Unable to load DLL path: " + dllPath +
 			" LoadLibrary " + GetLastErrorString()
 		);
 	}
-
-	this->moduleDllHandle.reset(dllHandle);
 
 	DetectExportedModuleFunctions();
 }

--- a/srcStatic/GameModules/DllModule.cpp
+++ b/srcStatic/GameModules/DllModule.cpp
@@ -19,7 +19,7 @@ void DllModule::LoadModuleDll(const std::string& dllPath)
 		);
 	}
 
-	this->moduleDllHandle = dllHandle;
+	this->moduleDllHandle.reset(dllHandle);
 
 	DetectExportedModuleFunctions();
 }
@@ -66,9 +66,7 @@ bool DllModule::Unload()
 		}
 	}
 
-	if (moduleDllHandle) {
-		FreeLibrary(moduleDllHandle);
-	}
+	moduleDllHandle.reset(nullptr);
 
 	return success;
 }

--- a/srcStatic/GameModules/DllModule.h
+++ b/srcStatic/GameModules/DllModule.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../GameModule.h"
+#include "../WindowsUniqueModule.h"
 #include <windows.h>
 #include <string>
 #include <type_traits>
@@ -17,7 +18,7 @@ public:
 	void Run() override;
 
 protected:
-	HINSTANCE moduleDllHandle = nullptr;
+	UniqueModule moduleDllHandle = nullptr;
 
 	// Call from constructor of derived class
 	void LoadModuleDll(const std::string& dllPath);
@@ -36,7 +37,7 @@ private:
 	template <typename ExportType>
 	ExportType GetExportAddress(const char* exportName) {
 		static_assert(std::is_pointer<ExportType>::value, "Type must be a pointer");
-		return reinterpret_cast<ExportType>(GetProcAddress(moduleDllHandle, exportName));
+		return reinterpret_cast<ExportType>(GetProcAddress(moduleDllHandle.get(), exportName));
 	}
 
 	LoadModuleFunctionIni loadModuleFunctionIni = nullptr;

--- a/srcStatic/WindowsUniqueModule.h
+++ b/srcStatic/WindowsUniqueModule.h
@@ -1,0 +1,18 @@
+#include <windows.h>
+#include <memory>
+
+
+// Sentinel value guarded HMODULE deleter
+// For use with LoadLibrary (will automatically call FreeLibrary)
+struct ModuleDeleter {
+	using pointer = HMODULE;
+
+	void operator()(HMODULE handle) const {
+		if (handle != NULL) {
+			FreeLibrary(handle);
+		}
+	}
+};
+
+
+using UniqueModule = std::unique_ptr<HMODULE, ModuleDeleter>;

--- a/srcStatic/op2extStatic.vcxproj
+++ b/srcStatic/op2extStatic.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="WindowsErrorCode.h" />
     <ClInclude Include="WindowsModule.h" />
     <ClInclude Include="WindowsUniqueHandle.h" />
+    <ClInclude Include="WindowsUniqueModule.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/srcStatic/op2extStatic.vcxproj.filters
+++ b/srcStatic/op2extStatic.vcxproj.filters
@@ -65,6 +65,7 @@
       <Filter>GameModules</Filter>
     </ClInclude>
     <ClInclude Include="WindowsUniqueHandle.h" />
+    <ClInclude Include="WindowsUniqueModule.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="GameModules">


### PR DESCRIPTION
This closes #195. This completes the secondary minor point in that issue about a corresponding `std::unique_ptr` based RAII style class to handle `HINSTANCE` values returned by `LoadLibrary`.
