### PR TITLE
Resolve OP2Memory parameter consistency

### DIFF
--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -15,9 +15,9 @@ constexpr std::uintptr_t ExpectedOutpost2Address = 0x00400000;
 // Returns true on success, or false on failure
 bool EnableOp2MemoryPatching()
 {
-	void* op2ModuleBase = GetModuleHandle(TEXT("Outpost2.exe"));
+	void* op2ModuleBaseAddress = GetModuleHandle(TEXT("Outpost2.exe"));
 
-	if (op2ModuleBase == nullptr) {
+	if (op2ModuleBaseAddress == nullptr) {
 		// Could not find Outpost2.exe module base address
 		// This can never happen if Outpost2.exe was the one that loaded op2ext.dll
 		// Failure likely means op2ext.dll was loaded elsewhere, such as a unit test
@@ -27,7 +27,7 @@ bool EnableOp2MemoryPatching()
 
 	// Enable memory patching for Outpost2.exe, and set relocation offset
 	memoryPatchingEnabled = true;
-	loadOffset = reinterpret_cast<std::uintptr_t>(op2ModuleBase) - ExpectedOutpost2Address;
+	loadOffset = reinterpret_cast<std::uintptr_t>(op2ModuleBaseAddress) - ExpectedOutpost2Address;
 	return true;
 }
 

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -40,8 +40,8 @@ bool Op2UnprotectMemory(std::uintptr_t destBaseAddress, std::size_t size)
 
 	void* destAddress = reinterpret_cast<void*>(destBaseAddress + loadOffset);
 	// Try to unprotect memory
-	DWORD oldAttr;
-	return VirtualProtect(destAddress, size, PAGE_EXECUTE_READWRITE, &oldAttr);
+	DWORD oldAttribute;
+	return VirtualProtect(destAddress, size, PAGE_EXECUTE_READWRITE, &oldAttribute);
 }
 
 
@@ -55,8 +55,8 @@ bool Op2MemEdit(std::uintptr_t destBaseAddress, std::size_t size, Function memor
 	void* destAddress = reinterpret_cast<void*>(destBaseAddress + loadOffset);
 
 	// Try to unprotect memory
-	DWORD oldAttr;
-	BOOL bSuccess = VirtualProtect(destAddress, size, PAGE_EXECUTE_READWRITE, &oldAttr);
+	DWORD oldAttribute;
+	BOOL bSuccess = VirtualProtect(destAddress, size, PAGE_EXECUTE_READWRITE, &oldAttribute);
 	if (!bSuccess) {
 		LogError("Error unprotecting memory at: 0x" + AddrToHexString(destAddress) + ".");
 		return false;
@@ -65,8 +65,8 @@ bool Op2MemEdit(std::uintptr_t destBaseAddress, std::size_t size, Function memor
 	memoryEditFunction(destAddress, size);
 
 	// Reprotect memory with the original attributes
-	DWORD ignoredAttr;
-	bSuccess = VirtualProtect(destAddress, size, oldAttr, &ignoredAttr);
+	DWORD ignoredAttribute;
+	bSuccess = VirtualProtect(destAddress, size, oldAttribute, &ignoredAttribute);
 
 	return (bSuccess != 0);
 }

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -105,7 +105,7 @@ bool Op2MemSetDword(std::uintptr_t destBaseAddr, const void* dword)
 // Example:  E8 = CALL, 00040000 = relative offset = <DWORD(&someMethod - &postCallInstruction)>
 //   CALL someMethod  ; Encoded as E8 00040000
 //   postCallInstruction:
-// The `callOffset` parameter is the address of the encoded DWORD
+// Patch address is of the instruction opcode (E8), which is verified before patching
 bool Op2RelinkCall(std::uintptr_t callOffset, const void* newFunctionAddress)
 {
 	if (!memoryPatchingEnabled) {

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -32,6 +32,19 @@ bool EnableOp2MemoryPatching()
 }
 
 
+bool Op2UnprotectMemory(std::uintptr_t destBaseAddr, std::size_t size)
+{
+	if (!memoryPatchingEnabled) {
+		return false;
+	}
+
+	void* destAddr = reinterpret_cast<void*>(destBaseAddr + loadOffset);
+	// Try to unprotect memory
+	DWORD oldAttr;
+	return VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
+}
+
+
 template <typename Function>
 bool Op2MemEdit(std::uintptr_t destBaseAddr, std::size_t size, Function memoryEditFunction)
 {
@@ -107,17 +120,4 @@ bool Op2RelinkCall(std::uintptr_t callOffset, const void* newFunctionAddress)
 
 	const auto postCallInstructionAddress = callOffset + loadOffset + (1 + sizeof(void*));
 	return Op2MemSetDword(callOffset + 1, reinterpret_cast<std::size_t>(newFunctionAddress) - postCallInstructionAddress);
-}
-
-
-bool Op2UnprotectMemory(std::uintptr_t destBaseAddr, std::size_t size)
-{
-	if (!memoryPatchingEnabled) {
-		return false;
-	}
-	
-	void* destAddr = reinterpret_cast<void*>(destBaseAddr + loadOffset);
-	// Try to unprotect memory
-	DWORD oldAttr;
-	return VirtualProtect(destAddr, size, PAGE_EXECUTE_READWRITE, &oldAttr);
 }

--- a/srcStatic/OP2Memory.cpp
+++ b/srcStatic/OP2Memory.cpp
@@ -106,18 +106,18 @@ bool Op2MemSetDword(std::uintptr_t destBaseAddr, const void* dword)
 //   CALL someMethod  ; Encoded as E8 00040000
 //   postCallInstruction:
 // Patch address is of the instruction opcode (E8), which is verified before patching
-bool Op2RelinkCall(std::uintptr_t callOffset, const void* newFunctionAddress)
+bool Op2RelinkCall(std::uintptr_t callInstructionAddr, const void* newFunctionAddress)
 {
 	if (!memoryPatchingEnabled) {
 		return false;
 	}
 
 	// Verify this is being run on a CALL instruction
-	if (*reinterpret_cast<unsigned char*>(callOffset + loadOffset) != 0xE8) {
-		LogError("Op2RelinkCall error: No CALL instruction found at given address: " + AddrToHexString(callOffset));
+	if (*reinterpret_cast<unsigned char*>(callInstructionAddr + loadOffset) != 0xE8) {
+		LogError("Op2RelinkCall error: No CALL instruction found at given address: " + AddrToHexString(callInstructionAddr));
 		return false;
 	}
 
-	const auto postCallInstructionAddress = callOffset + loadOffset + (1 + sizeof(void*));
-	return Op2MemSetDword(callOffset + 1, reinterpret_cast<std::size_t>(newFunctionAddress) - postCallInstructionAddress);
+	const auto postCallInstructionAddress = callInstructionAddr + loadOffset + (1 + sizeof(void*));
+	return Op2MemSetDword(callInstructionAddr + 1, reinterpret_cast<std::size_t>(newFunctionAddress) - postCallInstructionAddress);
 }

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -9,12 +9,12 @@
 
 bool EnableOp2MemoryPatching();
 
-bool Op2UnprotectMemory(std::uintptr_t destBaseAddr, std::size_t size);
-bool Op2MemCopy(std::uintptr_t destBaseAddr, std::size_t size, const void* sourceAddr);
-bool Op2MemSet(std::uintptr_t destBaseAddr, std::size_t size, unsigned char value);
-bool Op2MemSetDword(std::uintptr_t destBaseAddr, std::size_t dword);
-bool Op2MemSetDword(std::uintptr_t destBaseAddr, const void* dword);
-bool Op2RelinkCall(std::uintptr_t callInstructionAddr, const void* newFunctionAddress);
+bool Op2UnprotectMemory(std::uintptr_t destBaseAddress, std::size_t size);
+bool Op2MemCopy(std::uintptr_t destBaseAddress, std::size_t size, const void* sourceAddress);
+bool Op2MemSet(std::uintptr_t destBaseAddress, std::size_t size, unsigned char value);
+bool Op2MemSetDword(std::uintptr_t destBaseAddress, std::size_t dword);
+bool Op2MemSetDword(std::uintptr_t destBaseAddress, const void* dword);
+bool Op2RelinkCall(std::uintptr_t callInstructionAddress, const void* newFunctionAddress);
 
 
 template <typename MethodPointerType>

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -9,12 +9,12 @@
 
 bool EnableOp2MemoryPatching();
 
+bool Op2UnprotectMemory(std::uintptr_t destBaseAddr, std::size_t size);
 bool Op2MemCopy(std::uintptr_t destBaseAddr, std::size_t size, const void* sourceAddr);
 bool Op2MemSet(std::uintptr_t destBaseAddr, std::size_t size, unsigned char value);
 bool Op2MemSetDword(std::uintptr_t destBaseAddr, std::size_t dword);
 bool Op2MemSetDword(std::uintptr_t destBaseAddr, const void* dword);
 bool Op2RelinkCall(std::uintptr_t callOffset, const void* newFunctionAddress);
-bool Op2UnprotectMemory(std::uintptr_t destBaseAddr, std::size_t size);
 
 
 template <typename MethodPointerType>

--- a/srcStatic/OP2Memory.h
+++ b/srcStatic/OP2Memory.h
@@ -14,7 +14,7 @@ bool Op2MemCopy(std::uintptr_t destBaseAddr, std::size_t size, const void* sourc
 bool Op2MemSet(std::uintptr_t destBaseAddr, std::size_t size, unsigned char value);
 bool Op2MemSetDword(std::uintptr_t destBaseAddr, std::size_t dword);
 bool Op2MemSetDword(std::uintptr_t destBaseAddr, const void* dword);
-bool Op2RelinkCall(std::uintptr_t callOffset, const void* newFunctionAddress);
+bool Op2RelinkCall(std::uintptr_t callInstructionAddr, const void* newFunctionAddress);
 
 
 template <typename MethodPointerType>


### PR DESCRIPTION
This closes #274.

I figure there is good reason to maintain a distinction in parameter names between `std::uintptr_t destBaseAddress` and `std::uintptr_t callInstructionAddress`. The former name is for generic memory editing functions, while the later is specifically for a `CALL` instruction editing function.

Touched on here is abbreviated versus full names. I think we should tend to use full names, though I haven't applied that rule consistently. There are still quite a few abbreviated names throughout the source code.
