### PR TITLE
Remove conditional compile check for debug logging

### DIFF
--- a/srcStatic/Log/LoggerDebug.cpp
+++ b/srcStatic/Log/LoggerDebug.cpp
@@ -5,7 +5,5 @@
 
 void LoggerDebug::Log(const std::string& message)
 {
-#ifdef DEBUG
 	OutputDebugString(message.c_str());
-#endif
 }


### PR DESCRIPTION
Logging to an attached debugger should be allowed under any build configuration.

This is something I wanted to change for ages, but wanted to keep it separate from other changes.
