### PR TITLE
Allow calling LogError and LogDebug from external DLLs

### DIFF
--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -120,20 +120,17 @@ void GenericLog(const char* message, const void* moduleAddress, LogFunctionType 
 
 OP2EXT_API void Log(const char* message)
 {
-	const void* moduleAddress = _ReturnAddress();
-	GenericLog(message, moduleAddress, LogMessage);
+	GenericLog(message, _ReturnAddress(), LogMessage);
 }
 
 OP2EXT_API void LogError(const char* message)
 {
-	const void* moduleAddress = _ReturnAddress();
-	GenericLog(message, moduleAddress, LogError);
+	GenericLog(message, _ReturnAddress(), LogError);
 }
 
 OP2EXT_API void LogDebug(const char* message)
 {
-	const void* moduleAddress = _ReturnAddress();
-	GenericLog(message, moduleAddress, LogDebug);
+	GenericLog(message, _ReturnAddress(), LogDebug);
 }
 
 

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -91,7 +91,9 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 	}
 }
 
-OP2EXT_API void Log(const char* message)
+
+template <typename LogFunction>
+void GenericLog(const char* message, LogFunction logFunction)
 {
 	// The return address will (normally) point into the code section
 	// of the caller. The address can then be used to lookup which
@@ -108,11 +110,27 @@ OP2EXT_API void Log(const char* message)
 	// calls across a module boundary (such as to exported methods).
 
 	try {
-		LogMessage(FormatLogMessage(message, FindModuleName(_ReturnAddress())));
-	} catch(const std::exception& e) {
+		logFunction(FormatLogMessage(message, FindModuleName(_ReturnAddress())));
+	}
+	catch (const std::exception& e) {
 		LogMessage("Error attempting to Log message from module. Return address to module is: " + AddrToHexString(_ReturnAddress()) + "  Error: " + e.what());
 		LogMessage(FormatLogMessage(message, "<UnknownModule>"));
 	}
+}
+
+OP2EXT_API void Log(const char* message)
+{
+	GenericLog(message, LogMessage);
+}
+
+OP2EXT_API void LogErrorMessage(const char* message)
+{
+	GenericLog(message, LogError);
+}
+
+OP2EXT_API void LogDebugMessage(const char* message)
+{
+	GenericLog(message, LogDebug);
 }
 
 

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -91,9 +91,9 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 	}
 }
 
+using LogFunctionType = void(*)(const std::string&);
 
-template <typename LogFunction>
-void GenericLog(const char* message, LogFunction logFunction)
+void GenericLog(const char* message, const void* moduleAddress, LogFunctionType logFunction)
 {
 	// The return address will (normally) point into the code section
 	// of the caller. The address can then be used to lookup which
@@ -110,7 +110,7 @@ void GenericLog(const char* message, LogFunction logFunction)
 	// calls across a module boundary (such as to exported methods).
 
 	try {
-		logFunction(FormatLogMessage(message, FindModuleName(_ReturnAddress())));
+		logFunction(FormatLogMessage(message, FindModuleName(moduleAddress)));
 	}
 	catch (const std::exception& e) {
 		LogMessage("Error attempting to Log message from module. Return address to module is: " + AddrToHexString(_ReturnAddress()) + "  Error: " + e.what());
@@ -120,17 +120,20 @@ void GenericLog(const char* message, LogFunction logFunction)
 
 OP2EXT_API void Log(const char* message)
 {
-	GenericLog(message, LogMessage);
+	const void* moduleAddress = _ReturnAddress();
+	GenericLog(message, moduleAddress, LogMessage);
 }
 
-OP2EXT_API void LogErrorMessage(const char* message)
+OP2EXT_API void LogError(const char* message)
 {
-	GenericLog(message, LogError);
+	const void* moduleAddress = _ReturnAddress();
+	GenericLog(message, moduleAddress, LogError);
 }
 
-OP2EXT_API void LogDebugMessage(const char* message)
+OP2EXT_API void LogDebug(const char* message)
 {
-	GenericLog(message, LogDebug);
+	const void* moduleAddress = _ReturnAddress();
+	GenericLog(message, moduleAddress, LogDebug);
 }
 
 

--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -19,6 +19,10 @@
 extern "C" OP2EXT_API int StubExt;
 int StubExt = 0;
 
+using LogFunctionType = void(*)(const std::string&);
+void GenericLog(const char* message, const void* moduleAddress, LogFunctionType logFunction);
+
+
 OP2EXT_API size_t GetGameDir_s(char* buffer, size_t bufferSize)
 {
 	// Adding "\\" to end of directory is required for backward compatibility.
@@ -91,7 +95,21 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch)
 	}
 }
 
-using LogFunctionType = void(*)(const std::string&);
+
+OP2EXT_API void Log(const char* message)
+{
+	GenericLog(message, _ReturnAddress(), LogMessage);
+}
+
+OP2EXT_API void LogError(const char* message)
+{
+	GenericLog(message, _ReturnAddress(), LogError);
+}
+
+OP2EXT_API void LogDebug(const char* message)
+{
+	GenericLog(message, _ReturnAddress(), LogDebug);
+}
 
 void GenericLog(const char* message, const void* moduleAddress, LogFunctionType logFunction)
 {
@@ -116,21 +134,6 @@ void GenericLog(const char* message, const void* moduleAddress, LogFunctionType 
 		LogMessage("Error attempting to Log message from module. Return address to module is: " + AddrToHexString(_ReturnAddress()) + "  Error: " + e.what());
 		LogMessage(FormatLogMessage(message, "<UnknownModule>"));
 	}
-}
-
-OP2EXT_API void Log(const char* message)
-{
-	GenericLog(message, _ReturnAddress(), LogMessage);
-}
-
-OP2EXT_API void LogError(const char* message)
-{
-	GenericLog(message, _ReturnAddress(), LogError);
-}
-
-OP2EXT_API void LogDebug(const char* message)
-{
-	GenericLog(message, _ReturnAddress(), LogDebug);
 }
 
 

--- a/srcDLL/op2ext.h
+++ b/srcDLL/op2ext.h
@@ -56,9 +56,16 @@ OP2EXT_API void AddVolToList(const char* volFilename);
 // See the ReadMe for detailed usage. Each variable must be a numeric value between 0-9 and not an ASCII character.
 OP2EXT_API void SetSerialNumber(char major, char minor, char patch);
 
-// Log a message in Outpost2Log.txt.
+// Standard message logging. Use for information that could help with diagnosing or fixing a problem but 
+// may not need the immediate attention of the user.
 OP2EXT_API void Log(const char* message);
 
+// Error logging. Reserve for logging critical information that is important enough it may modally interrupt the user.
+OP2EXT_API void LogErrorMessage(const char* message);
+
+// Log debug messaging. Reserve for logging detailed or lenghty information that could bloat the log file long term. 
+// Use for information that could be useful during debugging, but not necessarily actionable by an end user.
+OP2EXT_API void LogDebugMessage(const char* message);
 
 // Performs a case insensitive search of loaded module names, returning true if found.
 // Returns false if passed an empty string (Module name cannot be empty).

--- a/srcDLL/op2ext.h
+++ b/srcDLL/op2ext.h
@@ -61,11 +61,11 @@ OP2EXT_API void SetSerialNumber(char major, char minor, char patch);
 OP2EXT_API void Log(const char* message);
 
 // Error logging. Reserve for logging critical information that is important enough it may modally interrupt the user.
-OP2EXT_API void LogErrorMessage(const char* message);
+OP2EXT_API void LogError(const char* message);
 
 // Log debug messaging. Reserve for logging detailed or lenghty information that could bloat the log file long term. 
 // Use for information that could be useful during debugging, but not necessarily actionable by an end user.
-OP2EXT_API void LogDebugMessage(const char* message);
+OP2EXT_API void LogDebug(const char* message);
 
 // Performs a case insensitive search of loaded module names, returning true if found.
 // Returns false if passed an empty string (Module name cannot be empty).

--- a/testDll/op2ext.test.cpp
+++ b/testDll/op2ext.test.cpp
@@ -151,7 +151,10 @@ TEST(op2ext, SetSerialNumber) {
 
 TEST(op2ext, Log) {
 	// Can log any text message
-	EXPECT_NO_THROW(Log("Test adding a message to log file"));
+	EXPECT_NO_THROW(Log("Test calling a standard log"));
+	//Calling LogError will force a modal dialog to pop up.
+	//EXPECT_NO_THROW(LogError("Test calling an error message"));
+	EXPECT_NO_THROW(LogDebug("Test calling a debug message \n"));
 }
 
 TEST(op2ext, IsModuleLoaded) {


### PR DESCRIPTION
Closes #64 

I wanted input on the external function names before writing test code.

The Issue suggested:
```C++
Log(char* message); // Normal logging
LogError(char* message); // Very serious error, maybe with a popup
LogDebug(char* message); // For really verbose stuff that may not be so interesting
```

Which I would be fine with. However the private template function I wrote throws an error because it cannot distinguish between two overloads for LogError. One version being the internal function within op2ext and the other being now contained in op2ext.h for other dlls to call.