### PR TITLE
Insert newline character automatically when calling LogDebug

### DIFF
--- a/srcStatic/Log/LoggerDebug.cpp
+++ b/srcStatic/Log/LoggerDebug.cpp
@@ -2,15 +2,9 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-#ifdef _WIN32
 const std::string newline("\r\n");
-#elif defined macintosh // OS 9
-const std::string newline("\r");
-#else
-const std::string newline("\n") // Mac OS X uses \n
-#endif
 
 void LoggerDebug::Log(const std::string& message)
 {
-	OutputDebugString(std::string(message + newline).c_str());
+	OutputDebugString((message + newline).c_str());
 }

--- a/srcStatic/Log/LoggerDebug.cpp
+++ b/srcStatic/Log/LoggerDebug.cpp
@@ -2,8 +2,15 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
+#ifdef _WIN32
+const std::string newline("\r\n");
+#elif defined macintosh // OS 9
+const std::string newline("\r");
+#else
+const std::string newline("\n") // Mac OS X uses \n
+#endif
 
 void LoggerDebug::Log(const std::string& message)
 {
-	OutputDebugString(message.c_str());
+	OutputDebugString(std::string(message + newline).c_str());
 }

--- a/srcStatic/Log/LoggerDebug.cpp
+++ b/srcStatic/Log/LoggerDebug.cpp
@@ -2,7 +2,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-const std::string newline("\r\n");
+const std::string newline("\n");
 
 void LoggerDebug::Log(const std::string& message)
 {

--- a/srcStatic/Log/LoggerDebug.cpp
+++ b/srcStatic/Log/LoggerDebug.cpp
@@ -2,9 +2,7 @@
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
-const std::string newline("\n");
-
 void LoggerDebug::Log(const std::string& message)
 {
-	OutputDebugString((message + newline).c_str());
+	OutputDebugString((message + "\n").c_str());
 }


### PR DESCRIPTION
I'm reading that whenever std::endl is called, std::flush is called. I think maybe we want to move away from endl? Unfortunatley, there doesn't appear to be a dropin Environment.Newline like in C# in C++.