### PR TITLE
Improve documentation of GetConsoleModDir_s & GetConsoleModDir

### DIFF
--- a/srcDLL/op2ext.cpp
+++ b/srcDLL/op2ext.cpp
@@ -31,15 +31,15 @@ OP2EXT_API size_t GetGameDir_s(char* buffer, size_t bufferSize)
 
 OP2EXT_API size_t GetConsoleModDir_s(char* buffer, size_t bufferSize)
 {
-	std::string consoleModuleDirectory;
+	std::string moduleDirectory;
 
 	// Try to determine calling module
 	auto module = moduleLoader->FindModule(FindModuleHandle(_ReturnAddress()));
 	if (module) {
-		consoleModuleDirectory = module->Directory();
+		moduleDirectory = module->Directory();
 	}
 	// Copy module directory to supplied buffer
-	return CopyStringViewIntoCharBuffer(consoleModuleDirectory, buffer, bufferSize);
+	return CopyStringViewIntoCharBuffer(moduleDirectory, buffer, bufferSize);
 }
 
 OP2EXT_API void GetGameDir(char* buffer)

--- a/srcDLL/op2ext.h
+++ b/srcDLL/op2ext.h
@@ -32,13 +32,15 @@ __declspec(deprecated("GetGameDir was deprecated in op2ext ver2.0.0. Use GetGame
 OP2EXT_API void GetGameDir(char* buffer);
 
 
-// Retrieves the absolute directory of the command line module with a trailing slash.
+// Retrieves the absolute directory of the calling module with a trailing slash.
+// Post version 2.2.0 of op2ext, also works for ini modules
 // If bufferSize is smaller than required to copy entire path, buffer is provided as much of path as possible.
 // Returns 0 on success. Returns the required minimum size of the buffer on failure.
 OP2EXT_API size_t GetConsoleModDir_s(char* buffer, size_t bufferSize);
 
 
-// Returns the absolute directory of the command line module through a pointer to a buffer
+// Returns the absolute directory of the calling module through a pointer to a buffer
+// Post version 2.2.0 of op2ext, also works for ini modules
 // The consumer must free the buffer when finished with it.
 __declspec(deprecated("GetCurrentModDir was deprecated in op2ext ver2.1.0. Use GetConsoleModDir_s instead."))
 OP2EXT_API char* GetCurrentModDir();


### PR DESCRIPTION
To prevent breaking change, the function name has not changed, but now the function can pull the directory of ini modules.