### PR TITLE
Updated release build to only include op2ext.dll and op2ext.pdb

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -32,9 +32,8 @@ after_build:
   - set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%PLATFORM%\%CONFIGURATION%\
   - if not exist "%OutputFolder%" set OutputFolder=%APPVEYOR_BUILD_FOLDER%\%CONFIGURATION%\
   # Package artifacts
-  - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.exe" "%OutputFolder%*.dll"
-  # - 7z a "%PackageBaseName%.zip" "%OutputFolder%*.lib"
-  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%*.pdb"
+  - 7z a "%PackageBaseName%.zip" "%OutputFolder%op2ext.dll"
+  - 7z a "%PackageBaseName%-DebugSymbolPdb.zip" "%OutputFolder%op2ext.pdb"
 artifacts:
   - path: "*.zip"
     name: BuildArtifacts


### PR DESCRIPTION
Still allow all artifacts for non-release tagged releases.

There is room to exclude the two gtest pdb files as well from the non-release tag artifacts, but maybe ok if they are present.

Closes #301